### PR TITLE
Update `go.mod` to make it compatible with go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github/hashicorp/terraform-provider-code-generator
+module github.com/hashicorp/terraform-plugin-codegen-framework
 
 go 1.20
 

--- a/internal/datasource_convert/attributes.go
+++ b/internal/datasource_convert/attributes.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertAttribute(a datasource.Attribute) (datasource_generate.GeneratorAttribute, error) {

--- a/internal/datasource_convert/blocks.go
+++ b/internal/datasource_convert/blocks.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertBlock(b datasource.Block) (datasource_generate.GeneratorBlock, error) {

--- a/internal/datasource_convert/bool_attribute.go
+++ b/internal/datasource_convert/bool_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertBoolAttribute(a *datasource.BoolAttribute) (datasource_generate.GeneratorBoolAttribute, error) {

--- a/internal/datasource_convert/bool_attribute_test.go
+++ b/internal/datasource_convert/bool_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertBoolAttribute(t *testing.T) {

--- a/internal/datasource_convert/convert.go
+++ b/internal/datasource_convert/convert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 type converter struct {

--- a/internal/datasource_convert/convert_test.go
+++ b/internal/datasource_convert/convert_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func pointer[T any](in T) *T {

--- a/internal/datasource_convert/float64_attribute.go
+++ b/internal/datasource_convert/float64_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertFloat64Attribute(a *datasource.Float64Attribute) (datasource_generate.GeneratorFloat64Attribute, error) {

--- a/internal/datasource_convert/float64_attribute_test.go
+++ b/internal/datasource_convert/float64_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertFloat64Attribute(t *testing.T) {

--- a/internal/datasource_convert/int64_attribute.go
+++ b/internal/datasource_convert/int64_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertInt64Attribute(a *datasource.Int64Attribute) (datasource_generate.GeneratorInt64Attribute, error) {

--- a/internal/datasource_convert/int64_attribute_test.go
+++ b/internal/datasource_convert/int64_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertInt64Attribute(t *testing.T) {

--- a/internal/datasource_convert/list_attribute.go
+++ b/internal/datasource_convert/list_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertListAttribute(a *datasource.ListAttribute) (datasource_generate.GeneratorListAttribute, error) {

--- a/internal/datasource_convert/list_attribute_test.go
+++ b/internal/datasource_convert/list_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertListAttribute(t *testing.T) {

--- a/internal/datasource_convert/list_nested_attribute.go
+++ b/internal/datasource_convert/list_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertListNestedAttribute(a *datasource.ListNestedAttribute) (datasource_generate.GeneratorListNestedAttribute, error) {

--- a/internal/datasource_convert/list_nested_attribute_test.go
+++ b/internal/datasource_convert/list_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertListNestedAttribute(t *testing.T) {

--- a/internal/datasource_convert/list_nested_block.go
+++ b/internal/datasource_convert/list_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertListNestedBlock(b *datasource.ListNestedBlock) (datasource_generate.GeneratorListNestedBlock, error) {

--- a/internal/datasource_convert/list_nested_block_test.go
+++ b/internal/datasource_convert/list_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertListNestedBlock(t *testing.T) {

--- a/internal/datasource_convert/map_attribute.go
+++ b/internal/datasource_convert/map_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertMapAttribute(a *datasource.MapAttribute) (datasource_generate.GeneratorMapAttribute, error) {

--- a/internal/datasource_convert/map_attribute_test.go
+++ b/internal/datasource_convert/map_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertMapAttribute(t *testing.T) {

--- a/internal/datasource_convert/map_nested_attribute.go
+++ b/internal/datasource_convert/map_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertMapNestedAttribute(a *datasource.MapNestedAttribute) (datasource_generate.GeneratorMapNestedAttribute, error) {

--- a/internal/datasource_convert/map_nested_attribute_test.go
+++ b/internal/datasource_convert/map_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertMapNestedAttribute(t *testing.T) {

--- a/internal/datasource_convert/number_attribute.go
+++ b/internal/datasource_convert/number_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertNumberAttribute(a *datasource.NumberAttribute) (datasource_generate.GeneratorNumberAttribute, error) {

--- a/internal/datasource_convert/number_attribute_test.go
+++ b/internal/datasource_convert/number_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertNumberAttribute(t *testing.T) {

--- a/internal/datasource_convert/object_attribute.go
+++ b/internal/datasource_convert/object_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertObjectAttribute(o *datasource.ObjectAttribute) (datasource_generate.GeneratorObjectAttribute, error) {

--- a/internal/datasource_convert/object_attribute_test.go
+++ b/internal/datasource_convert/object_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertObjectAttribute(t *testing.T) {

--- a/internal/datasource_convert/schema.go
+++ b/internal/datasource_convert/schema.go
@@ -6,7 +6,7 @@ package datasource_convert
 import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertSchema(d datasource.DataSource) (datasource_generate.GeneratorDataSourceSchema, error) {

--- a/internal/datasource_convert/set_attribute.go
+++ b/internal/datasource_convert/set_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertSetAttribute(a *datasource.SetAttribute) (datasource_generate.GeneratorSetAttribute, error) {

--- a/internal/datasource_convert/set_attribute_test.go
+++ b/internal/datasource_convert/set_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertSetAttribute(t *testing.T) {

--- a/internal/datasource_convert/set_nested_attribute.go
+++ b/internal/datasource_convert/set_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertSetNestedAttribute(a *datasource.SetNestedAttribute) (datasource_generate.GeneratorSetNestedAttribute, error) {

--- a/internal/datasource_convert/set_nested_attribute_test.go
+++ b/internal/datasource_convert/set_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertSetNestedAttribute(t *testing.T) {

--- a/internal/datasource_convert/set_nested_block.go
+++ b/internal/datasource_convert/set_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertSetNestedBlock(b *datasource.SetNestedBlock) (datasource_generate.GeneratorSetNestedBlock, error) {

--- a/internal/datasource_convert/set_nested_block_test.go
+++ b/internal/datasource_convert/set_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertSetNestedBlock(t *testing.T) {

--- a/internal/datasource_convert/single_nested_attribute.go
+++ b/internal/datasource_convert/single_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertSingleNestedAttribute(a *datasource.SingleNestedAttribute) (datasource_generate.GeneratorSingleNestedAttribute, error) {

--- a/internal/datasource_convert/single_nested_attribute_test.go
+++ b/internal/datasource_convert/single_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertSingleNestedAttribute(t *testing.T) {

--- a/internal/datasource_convert/single_nested_block.go
+++ b/internal/datasource_convert/single_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertSingleNestedBlock(b *datasource.SingleNestedBlock) (datasource_generate.GeneratorSingleNestedBlock, error) {

--- a/internal/datasource_convert/single_nested_block_test.go
+++ b/internal/datasource_convert/single_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertSingleNestedBlock(t *testing.T) {

--- a/internal/datasource_convert/string_attribute.go
+++ b/internal/datasource_convert/string_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func convertStringAttribute(a *datasource.StringAttribute) (datasource_generate.GeneratorStringAttribute, error) {

--- a/internal/datasource_convert/string_attribute_test.go
+++ b/internal/datasource_convert/string_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
 )
 
 func TestConvertStringAttribute(t *testing.T) {

--- a/internal/gen/generate_test.go
+++ b/internal/gen/generate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/format"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/format"
 )
 
 func TestDataSourcesModels(t *testing.T) {

--- a/internal/provider_convert/attributes.go
+++ b/internal/provider_convert/attributes.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertAttribute(a provider.Attribute) (provider_generate.GeneratorAttribute, error) {

--- a/internal/provider_convert/blocks.go
+++ b/internal/provider_convert/blocks.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertBlock(b provider.Block) (provider_generate.GeneratorBlock, error) {

--- a/internal/provider_convert/bool_attribute.go
+++ b/internal/provider_convert/bool_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertBoolAttribute(a *provider.BoolAttribute) (provider_generate.GeneratorBoolAttribute, error) {

--- a/internal/provider_convert/bool_attribute_test.go
+++ b/internal/provider_convert/bool_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertBoolAttribute(t *testing.T) {

--- a/internal/provider_convert/convert.go
+++ b/internal/provider_convert/convert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 type converter struct {

--- a/internal/provider_convert/convert_test.go
+++ b/internal/provider_convert/convert_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func pointer[T any](in T) *T {

--- a/internal/provider_convert/float64_attribute.go
+++ b/internal/provider_convert/float64_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertFloat64Attribute(a *provider.Float64Attribute) (provider_generate.GeneratorFloat64Attribute, error) {

--- a/internal/provider_convert/float64_attribute_test.go
+++ b/internal/provider_convert/float64_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertFloat64Attribute(t *testing.T) {

--- a/internal/provider_convert/int64_attribute.go
+++ b/internal/provider_convert/int64_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertInt64Attribute(a *provider.Int64Attribute) (provider_generate.GeneratorInt64Attribute, error) {

--- a/internal/provider_convert/int64_attribute_test.go
+++ b/internal/provider_convert/int64_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertInt64Attribute(t *testing.T) {

--- a/internal/provider_convert/list_attribute.go
+++ b/internal/provider_convert/list_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertListAttribute(a *provider.ListAttribute) (provider_generate.GeneratorListAttribute, error) {

--- a/internal/provider_convert/list_attribute_test.go
+++ b/internal/provider_convert/list_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertListAttribute(t *testing.T) {

--- a/internal/provider_convert/list_nested_attribute.go
+++ b/internal/provider_convert/list_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertListNestedAttribute(a *provider.ListNestedAttribute) (provider_generate.GeneratorListNestedAttribute, error) {

--- a/internal/provider_convert/list_nested_attribute_test.go
+++ b/internal/provider_convert/list_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertListNestedAttribute(t *testing.T) {

--- a/internal/provider_convert/list_nested_block.go
+++ b/internal/provider_convert/list_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertListNestedBlock(b *provider.ListNestedBlock) (provider_generate.GeneratorListNestedBlock, error) {

--- a/internal/provider_convert/list_nested_block_test.go
+++ b/internal/provider_convert/list_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertListNestedBlock(t *testing.T) {

--- a/internal/provider_convert/map_attribute.go
+++ b/internal/provider_convert/map_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertMapAttribute(a *provider.MapAttribute) (provider_generate.GeneratorMapAttribute, error) {

--- a/internal/provider_convert/map_attribute_test.go
+++ b/internal/provider_convert/map_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertMapAttribute(t *testing.T) {

--- a/internal/provider_convert/map_nested_attribute.go
+++ b/internal/provider_convert/map_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertMapNestedAttribute(a *provider.MapNestedAttribute) (provider_generate.GeneratorMapNestedAttribute, error) {

--- a/internal/provider_convert/map_nested_attribute_test.go
+++ b/internal/provider_convert/map_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertMapNestedAttribute(t *testing.T) {

--- a/internal/provider_convert/number_attribute.go
+++ b/internal/provider_convert/number_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertNumberAttribute(a *provider.NumberAttribute) (provider_generate.GeneratorNumberAttribute, error) {

--- a/internal/provider_convert/number_attribute_test.go
+++ b/internal/provider_convert/number_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertNumberAttribute(t *testing.T) {

--- a/internal/provider_convert/object_attribute.go
+++ b/internal/provider_convert/object_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertObjectAttribute(o *provider.ObjectAttribute) (provider_generate.GeneratorObjectAttribute, error) {

--- a/internal/provider_convert/object_attribute_test.go
+++ b/internal/provider_convert/object_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertObjectAttribute(t *testing.T) {

--- a/internal/provider_convert/schema.go
+++ b/internal/provider_convert/schema.go
@@ -6,7 +6,7 @@ package provider_convert
 import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertSchema(d *provider.Provider) (provider_generate.GeneratorProviderSchema, error) {

--- a/internal/provider_convert/set_attribute.go
+++ b/internal/provider_convert/set_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertSetAttribute(a *provider.SetAttribute) (provider_generate.GeneratorSetAttribute, error) {

--- a/internal/provider_convert/set_attribute_test.go
+++ b/internal/provider_convert/set_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertSetAttribute(t *testing.T) {

--- a/internal/provider_convert/set_nested_attribute.go
+++ b/internal/provider_convert/set_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertSetNestedAttribute(a *provider.SetNestedAttribute) (provider_generate.GeneratorSetNestedAttribute, error) {

--- a/internal/provider_convert/set_nested_attribute_test.go
+++ b/internal/provider_convert/set_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertSetNestedAttribute(t *testing.T) {

--- a/internal/provider_convert/set_nested_block.go
+++ b/internal/provider_convert/set_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertSetNestedBlock(b *provider.SetNestedBlock) (provider_generate.GeneratorSetNestedBlock, error) {

--- a/internal/provider_convert/set_nested_block_test.go
+++ b/internal/provider_convert/set_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertSetNestedBlock(t *testing.T) {

--- a/internal/provider_convert/single_nested_attribute.go
+++ b/internal/provider_convert/single_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertSingleNestedAttribute(a *provider.SingleNestedAttribute) (provider_generate.GeneratorSingleNestedAttribute, error) {

--- a/internal/provider_convert/single_nested_attribute_test.go
+++ b/internal/provider_convert/single_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertSingleNestedAttribute(t *testing.T) {

--- a/internal/provider_convert/single_nested_block.go
+++ b/internal/provider_convert/single_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertSingleNestedBlock(b *provider.SingleNestedBlock) (provider_generate.GeneratorSingleNestedBlock, error) {

--- a/internal/provider_convert/single_nested_block_test.go
+++ b/internal/provider_convert/single_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertSingleNestedBlock(t *testing.T) {

--- a/internal/provider_convert/string_attribute.go
+++ b/internal/provider_convert/string_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func convertStringAttribute(a *provider.StringAttribute) (provider_generate.GeneratorStringAttribute, error) {

--- a/internal/provider_convert/string_attribute_test.go
+++ b/internal/provider_convert/string_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
 )
 
 func TestConvertStringAttribute(t *testing.T) {

--- a/internal/resource_convert/attributes.go
+++ b/internal/resource_convert/attributes.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertAttribute(a resource.Attribute) (resource_generate.GeneratorAttribute, error) {

--- a/internal/resource_convert/blocks.go
+++ b/internal/resource_convert/blocks.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertBlock(b resource.Block) (resource_generate.GeneratorBlock, error) {

--- a/internal/resource_convert/bool_attribute.go
+++ b/internal/resource_convert/bool_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertBoolAttribute(a *resource.BoolAttribute) (resource_generate.GeneratorBoolAttribute, error) {

--- a/internal/resource_convert/bool_attribute_test.go
+++ b/internal/resource_convert/bool_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertBoolAttribute(t *testing.T) {

--- a/internal/resource_convert/convert.go
+++ b/internal/resource_convert/convert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 type converter struct {

--- a/internal/resource_convert/convert_test.go
+++ b/internal/resource_convert/convert_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func pointer[T any](in T) *T {

--- a/internal/resource_convert/float64_attribute.go
+++ b/internal/resource_convert/float64_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertFloat64Attribute(a *resource.Float64Attribute) (resource_generate.GeneratorFloat64Attribute, error) {

--- a/internal/resource_convert/float64_attribute_test.go
+++ b/internal/resource_convert/float64_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertFloat64Attribute(t *testing.T) {

--- a/internal/resource_convert/int64_attribute.go
+++ b/internal/resource_convert/int64_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertInt64Attribute(a *resource.Int64Attribute) (resource_generate.GeneratorInt64Attribute, error) {

--- a/internal/resource_convert/int64_attribute_test.go
+++ b/internal/resource_convert/int64_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertInt64Attribute(t *testing.T) {

--- a/internal/resource_convert/list_attribute.go
+++ b/internal/resource_convert/list_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertListAttribute(a *resource.ListAttribute) (resource_generate.GeneratorListAttribute, error) {

--- a/internal/resource_convert/list_attribute_test.go
+++ b/internal/resource_convert/list_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertListAttribute(t *testing.T) {

--- a/internal/resource_convert/list_nested_attribute.go
+++ b/internal/resource_convert/list_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertListNestedAttribute(a *resource.ListNestedAttribute) (resource_generate.GeneratorListNestedAttribute, error) {

--- a/internal/resource_convert/list_nested_attribute_test.go
+++ b/internal/resource_convert/list_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertListNestedAttribute(t *testing.T) {

--- a/internal/resource_convert/list_nested_block.go
+++ b/internal/resource_convert/list_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertListNestedBlock(b *resource.ListNestedBlock) (resource_generate.GeneratorListNestedBlock, error) {

--- a/internal/resource_convert/list_nested_block_test.go
+++ b/internal/resource_convert/list_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertListNestedBlock(t *testing.T) {

--- a/internal/resource_convert/map_attribute.go
+++ b/internal/resource_convert/map_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertMapAttribute(a *resource.MapAttribute) (resource_generate.GeneratorMapAttribute, error) {

--- a/internal/resource_convert/map_attribute_test.go
+++ b/internal/resource_convert/map_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertMapAttribute(t *testing.T) {

--- a/internal/resource_convert/map_nested_attribute.go
+++ b/internal/resource_convert/map_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertMapNestedAttribute(a *resource.MapNestedAttribute) (resource_generate.GeneratorMapNestedAttribute, error) {

--- a/internal/resource_convert/map_nested_attribute_test.go
+++ b/internal/resource_convert/map_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertMapNestedAttribute(t *testing.T) {

--- a/internal/resource_convert/number_attribute.go
+++ b/internal/resource_convert/number_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertNumberAttribute(a *resource.NumberAttribute) (resource_generate.GeneratorNumberAttribute, error) {

--- a/internal/resource_convert/number_attribute_test.go
+++ b/internal/resource_convert/number_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertNumberAttribute(t *testing.T) {

--- a/internal/resource_convert/object_attribute.go
+++ b/internal/resource_convert/object_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertObjectAttribute(o *resource.ObjectAttribute) (resource_generate.GeneratorObjectAttribute, error) {

--- a/internal/resource_convert/object_attribute_test.go
+++ b/internal/resource_convert/object_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertObjectAttribute(t *testing.T) {

--- a/internal/resource_convert/schema.go
+++ b/internal/resource_convert/schema.go
@@ -6,7 +6,7 @@ package resource_convert
 import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertSchema(d resource.Resource) (resource_generate.GeneratorResourceSchema, error) {

--- a/internal/resource_convert/set_attribute.go
+++ b/internal/resource_convert/set_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertSetAttribute(a *resource.SetAttribute) (resource_generate.GeneratorSetAttribute, error) {

--- a/internal/resource_convert/set_attribute_test.go
+++ b/internal/resource_convert/set_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertSetAttribute(t *testing.T) {

--- a/internal/resource_convert/set_nested_attribute.go
+++ b/internal/resource_convert/set_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertSetNestedAttribute(a *resource.SetNestedAttribute) (resource_generate.GeneratorSetNestedAttribute, error) {

--- a/internal/resource_convert/set_nested_attribute_test.go
+++ b/internal/resource_convert/set_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertSetNestedAttribute(t *testing.T) {

--- a/internal/resource_convert/set_nested_block.go
+++ b/internal/resource_convert/set_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertSetNestedBlock(b *resource.SetNestedBlock) (resource_generate.GeneratorSetNestedBlock, error) {

--- a/internal/resource_convert/set_nested_block_test.go
+++ b/internal/resource_convert/set_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertSetNestedBlock(t *testing.T) {

--- a/internal/resource_convert/single_nested_attribute.go
+++ b/internal/resource_convert/single_nested_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertSingleNestedAttribute(a *resource.SingleNestedAttribute) (resource_generate.GeneratorSingleNestedAttribute, error) {

--- a/internal/resource_convert/single_nested_attribute_test.go
+++ b/internal/resource_convert/single_nested_attribute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertSingleNestedAttribute(t *testing.T) {

--- a/internal/resource_convert/single_nested_block.go
+++ b/internal/resource_convert/single_nested_block.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertSingleNestedBlock(b *resource.SingleNestedBlock) (resource_generate.GeneratorSingleNestedBlock, error) {

--- a/internal/resource_convert/single_nested_block_test.go
+++ b/internal/resource_convert/single_nested_block_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertSingleNestedBlock(t *testing.T) {

--- a/internal/resource_convert/string_attribute.go
+++ b/internal/resource_convert/string_attribute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func convertStringAttribute(a *resource.StringAttribute) (resource_generate.GeneratorStringAttribute, error) {

--- a/internal/resource_convert/string_attribute_test.go
+++ b/internal/resource_convert/string_attribute_test.go
@@ -12,7 +12,7 @@ import (
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
 )
 
 func TestConvertStringAttribute(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -11,17 +11,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/spec"
 	"github.com/mitchellh/cli"
 
-	"github/hashicorp/terraform-provider-code-generator/internal/config"
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_convert"
-	"github/hashicorp/terraform-provider-code-generator/internal/datasource_generate"
-	"github/hashicorp/terraform-provider-code-generator/internal/format"
-	"github/hashicorp/terraform-provider-code-generator/internal/input"
-	"github/hashicorp/terraform-provider-code-generator/internal/output"
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_convert"
-	"github/hashicorp/terraform-provider-code-generator/internal/provider_generate"
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_convert"
-	"github/hashicorp/terraform-provider-code-generator/internal/resource_generate"
-	"github/hashicorp/terraform-provider-code-generator/internal/validate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/config"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_convert"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/datasource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/format"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/input"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/output"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_convert"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/provider_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_convert"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/resource_generate"
+	"github.com/hashicorp/terraform-plugin-codegen-framework/internal/validate"
 )
 
 //go:generate go run main.go


### PR DESCRIPTION
Running the `go install` command produces the fun:
```bash
go install github.com/hashicorp/terraform-plugin-codegen-framework@latest
go: downloading github.com/hashicorp/terraform-plugin-codegen-framework v0.0.0-20230612162314-bc4b7f6a570b
go: github.com/hashicorp/terraform-plugin-codegen-framework@latest: github.com/hashicorp/terraform-plugin-codegen-framework@v0.0.0-20230612162314-bc4b7f6a570b: parsing go.mod:
	module declares its path as: github/hashicorp/terraform-provider-code-generator
	        but was required as: github.com/hashicorp/terraform-plugin-codegen-framework
```

Matching the name of the repo w/ module name should fix this I believe 👍🏻 