### PR TITLE
Refactor to reusable functions for generating imports for CustomType, Default, PlanModifier and Validator

### DIFF
--- a/internal/datasource_generate/bool_attribute.go
+++ b/internal/datasource_generate/bool_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -27,34 +26,12 @@ type GeneratorBoolAttribute struct {
 func (g GeneratorBoolAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/float64_attribute.go
+++ b/internal/datasource_generate/float64_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -27,34 +26,12 @@ type GeneratorFloat64Attribute struct {
 func (g GeneratorFloat64Attribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/int64_attribute.go
+++ b/internal/datasource_generate/int64_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -27,34 +26,12 @@ type GeneratorInt64Attribute struct {
 func (g GeneratorInt64Attribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/list_attribute.go
+++ b/internal/datasource_generate/list_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,38 +27,15 @@ type GeneratorListAttribute struct {
 func (g GeneratorListAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/list_nested_attribute.go
+++ b/internal/datasource_generate/list_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,64 +27,24 @@ type GeneratorListNestedAttribute struct {
 func (g GeneratorListNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/list_nested_attribute_test.go
+++ b/internal/datasource_generate/list_nested_attribute_test.go
@@ -33,7 +33,11 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 			input: GeneratorListNestedAttribute{
 				CustomType: &specschema.CustomType{},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-without-import": {
 			input: GeneratorListNestedAttribute{
@@ -64,7 +68,11 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 					},
 				},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-with-import-empty-string": {
 			input: GeneratorListNestedAttribute{
@@ -110,6 +118,9 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 			expected: []code.Import{
 				{
 					Path: "github.com/my_account/my_project/attribute",
+				},
+				{
+					Path: generatorschema.TypesImport,
 				},
 			},
 		},

--- a/internal/datasource_generate/list_nested_block.go
+++ b/internal/datasource_generate/list_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,68 +27,28 @@ type GeneratorListNestedBlock struct {
 func (g GeneratorListNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.NestedObject.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/list_nested_block_test.go
+++ b/internal/datasource_generate/list_nested_block_test.go
@@ -33,7 +33,11 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 			input: GeneratorListNestedBlock{
 				CustomType: &specschema.CustomType{},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-without-import": {
 			input: GeneratorListNestedBlock{
@@ -64,7 +68,11 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 					},
 				},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-with-import-empty-string": {
 			input: GeneratorListNestedBlock{
@@ -110,6 +118,9 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 			expected: []code.Import{
 				{
 					Path: "github.com/my_account/my_project/attribute",
+				},
+				{
+					Path: generatorschema.TypesImport,
 				},
 			},
 		},

--- a/internal/datasource_generate/map_attribute.go
+++ b/internal/datasource_generate/map_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,38 +27,15 @@ type GeneratorMapAttribute struct {
 func (g GeneratorMapAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/map_nested_attribute.go
+++ b/internal/datasource_generate/map_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,64 +27,24 @@ type GeneratorMapNestedAttribute struct {
 func (g GeneratorMapNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/number_attribute.go
+++ b/internal/datasource_generate/number_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -27,34 +26,12 @@ type GeneratorNumberAttribute struct {
 func (g GeneratorNumberAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/object_attribute.go
+++ b/internal/datasource_generate/object_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,38 +27,15 @@ type GeneratorObjectAttribute struct {
 func (g GeneratorObjectAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	attrTypesImports := generatorschema.GetAttrTypesImports(g.CustomType, g.AttributeTypes)
-
-	imports.Add(attrTypesImports.All()...)
+	imports.Append(attrTypesImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/set_attribute.go
+++ b/internal/datasource_generate/set_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,38 +27,15 @@ type GeneratorSetAttribute struct {
 func (g GeneratorSetAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/datasource_generate/set_nested_attribute.go
+++ b/internal/datasource_generate/set_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,64 +27,24 @@ type GeneratorSetNestedAttribute struct {
 func (g GeneratorSetNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/set_nested_block.go
+++ b/internal/datasource_generate/set_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,68 +27,28 @@ type GeneratorSetNestedBlock struct {
 func (g GeneratorSetNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.NestedObject.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/single_nested_attribute.go
+++ b/internal/datasource_generate/single_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -28,38 +27,16 @@ type GeneratorSingleNestedAttribute struct {
 func (g GeneratorSingleNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/single_nested_block.go
+++ b/internal/datasource_generate/single_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -29,42 +28,20 @@ type GeneratorSingleNestedBlock struct {
 func (g GeneratorSingleNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/datasource_generate/string_attribute.go
+++ b/internal/datasource_generate/string_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
@@ -27,34 +26,12 @@ type GeneratorStringAttribute struct {
 func (g GeneratorStringAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/bool_attribute.go
+++ b/internal/provider_generate/bool_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -27,34 +26,12 @@ type GeneratorBoolAttribute struct {
 func (g GeneratorBoolAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/float64_attribute.go
+++ b/internal/provider_generate/float64_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -27,34 +26,12 @@ type GeneratorFloat64Attribute struct {
 func (g GeneratorFloat64Attribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/int64_attribute.go
+++ b/internal/provider_generate/int64_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -27,34 +26,12 @@ type GeneratorInt64Attribute struct {
 func (g GeneratorInt64Attribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/list_attribute.go
+++ b/internal/provider_generate/list_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,38 +27,15 @@ type GeneratorListAttribute struct {
 func (g GeneratorListAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/list_nested_attribute.go
+++ b/internal/provider_generate/list_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,64 +27,24 @@ type GeneratorListNestedAttribute struct {
 func (g GeneratorListNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/list_nested_attribute_test.go
+++ b/internal/provider_generate/list_nested_attribute_test.go
@@ -33,7 +33,11 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 			input: GeneratorListNestedAttribute{
 				CustomType: &specschema.CustomType{},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-without-import": {
 			input: GeneratorListNestedAttribute{
@@ -64,7 +68,11 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 					},
 				},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-with-import-empty-string": {
 			input: GeneratorListNestedAttribute{
@@ -110,6 +118,9 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 			expected: []code.Import{
 				{
 					Path: "github.com/my_account/my_project/attribute",
+				},
+				{
+					Path: generatorschema.TypesImport,
 				},
 			},
 		},

--- a/internal/provider_generate/list_nested_block.go
+++ b/internal/provider_generate/list_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,68 +27,28 @@ type GeneratorListNestedBlock struct {
 func (g GeneratorListNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.NestedObject.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/list_nested_block_test.go
+++ b/internal/provider_generate/list_nested_block_test.go
@@ -33,7 +33,11 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 			input: GeneratorListNestedBlock{
 				CustomType: &specschema.CustomType{},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-without-import": {
 			input: GeneratorListNestedBlock{
@@ -64,7 +68,11 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 					},
 				},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-with-import-empty-string": {
 			input: GeneratorListNestedBlock{
@@ -110,6 +118,9 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 			expected: []code.Import{
 				{
 					Path: "github.com/my_account/my_project/attribute",
+				},
+				{
+					Path: generatorschema.TypesImport,
 				},
 			},
 		},

--- a/internal/provider_generate/map_attribute.go
+++ b/internal/provider_generate/map_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,38 +27,15 @@ type GeneratorMapAttribute struct {
 func (g GeneratorMapAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/map_nested_attribute.go
+++ b/internal/provider_generate/map_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,64 +27,24 @@ type GeneratorMapNestedAttribute struct {
 func (g GeneratorMapNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/object_attribute.go
+++ b/internal/provider_generate/object_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,38 +27,15 @@ type GeneratorObjectAttribute struct {
 func (g GeneratorObjectAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	attrTypesImports := generatorschema.GetAttrTypesImports(g.CustomType, g.AttributeTypes)
-
-	imports.Add(attrTypesImports.All()...)
+	imports.Append(attrTypesImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/set_attribute.go
+++ b/internal/provider_generate/set_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,38 +27,15 @@ type GeneratorSetAttribute struct {
 func (g GeneratorSetAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/provider_generate/set_nested_attribute.go
+++ b/internal/provider_generate/set_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,64 +27,24 @@ type GeneratorSetNestedAttribute struct {
 func (g GeneratorSetNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/set_nested_block.go
+++ b/internal/provider_generate/set_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,68 +27,28 @@ type GeneratorSetNestedBlock struct {
 func (g GeneratorSetNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
-
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
+
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.NestedObject.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/single_nested_attribute.go
+++ b/internal/provider_generate/single_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -28,38 +27,16 @@ type GeneratorSingleNestedAttribute struct {
 func (g GeneratorSingleNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/single_nested_block.go
+++ b/internal/provider_generate/single_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -29,42 +28,20 @@ type GeneratorSingleNestedBlock struct {
 func (g GeneratorSingleNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/provider_generate/string_attribute.go
+++ b/internal/provider_generate/string_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 
@@ -27,34 +26,12 @@ type GeneratorStringAttribute struct {
 func (g GeneratorStringAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/bool_attribute.go
+++ b/internal/resource_generate/bool_attribute.go
@@ -30,68 +30,28 @@ type GeneratorBoolAttribute struct {
 func (g GeneratorBoolAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
 		if g.Default.Static != nil {
 			imports.Add(code.Import{
 				Path: defaultBoolImport,
 			})
-		} else if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
+		} else {
+			customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+			imports.Append(customDefaultImports)
 		}
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/bool_attribute_test.go
+++ b/internal/resource_generate/bool_attribute_test.go
@@ -215,7 +215,7 @@ func TestGeneratorBoolAttribute_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/float64_attribute.go
+++ b/internal/resource_generate/float64_attribute.go
@@ -31,68 +31,28 @@ type GeneratorFloat64Attribute struct {
 func (g GeneratorFloat64Attribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
 		if g.Default.Static != nil {
 			imports.Add(code.Import{
-				Path: defaultBoolImport,
+				Path: defaultFloat64Import,
 			})
-		} else if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
+		} else {
+			customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+			imports.Append(customDefaultImports)
 		}
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/import.go
+++ b/internal/resource_generate/import.go
@@ -8,5 +8,4 @@ const (
 	defaultFloat64Import = "github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
 	defaultInt64Import   = "github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	defaultStringImport  = "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	planModifierImport   = "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )

--- a/internal/resource_generate/int64_attribute.go
+++ b/internal/resource_generate/int64_attribute.go
@@ -30,68 +30,28 @@ type GeneratorInt64Attribute struct {
 func (g GeneratorInt64Attribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
 		if g.Default.Static != nil {
 			imports.Add(code.Import{
-				Path: defaultBoolImport,
+				Path: defaultInt64Import,
 			})
-		} else if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
+		} else {
+			customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+			imports.Append(customDefaultImports)
 		}
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/list_attribute.go
+++ b/internal/resource_generate/list_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,68 +29,25 @@ type GeneratorListAttribute struct {
 func (g GeneratorListAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/list_attribute_test.go
+++ b/internal/resource_generate/list_attribute_test.go
@@ -387,7 +387,7 @@ func TestGeneratorListAttribute_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/list_nested_attribute.go
+++ b/internal/resource_generate/list_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,114 +29,39 @@ type GeneratorListNestedAttribute struct {
 func (g GeneratorListNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.NestedObject.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/list_nested_attribute_test.go
+++ b/internal/resource_generate/list_nested_attribute_test.go
@@ -33,7 +33,11 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 			input: GeneratorListNestedAttribute{
 				CustomType: &specschema.CustomType{},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-without-import": {
 			input: GeneratorListNestedAttribute{
@@ -64,7 +68,11 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 					},
 				},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-with-import-empty-string": {
 			input: GeneratorListNestedAttribute{
@@ -110,6 +118,9 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 			expected: []code.Import{
 				{
 					Path: "github.com/my_account/my_project/attribute",
+				},
+				{
+					Path: generatorschema.TypesImport,
 				},
 			},
 		},
@@ -567,7 +578,7 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",
@@ -732,7 +743,7 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/list_nested_block.go
+++ b/internal/resource_generate/list_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -29,108 +28,38 @@ type GeneratorListNestedBlock struct {
 func (g GeneratorListNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.NestedObject.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.NestedObject.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/list_nested_block_test.go
+++ b/internal/resource_generate/list_nested_block_test.go
@@ -33,7 +33,11 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 			input: GeneratorListNestedBlock{
 				CustomType: &specschema.CustomType{},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-without-import": {
 			input: GeneratorListNestedBlock{
@@ -64,7 +68,11 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 					},
 				},
 			},
-			expected: []code.Import{},
+			expected: []code.Import{
+				{
+					Path: generatorschema.TypesImport,
+				},
+			},
 		},
 		"nested-object-custom-type-with-import-empty-string": {
 			input: GeneratorListNestedBlock{
@@ -110,6 +118,9 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 			expected: []code.Import{
 				{
 					Path: "github.com/my_account/my_project/attribute",
+				},
+				{
+					Path: generatorschema.TypesImport,
 				},
 			},
 		},
@@ -590,7 +601,7 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",
@@ -686,7 +697,7 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/map_attribute.go
+++ b/internal/resource_generate/map_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,68 +29,25 @@ type GeneratorMapAttribute struct {
 func (g GeneratorMapAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/map_nested_attribute.go
+++ b/internal/resource_generate/map_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,114 +29,39 @@ type GeneratorMapNestedAttribute struct {
 func (g GeneratorMapNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.NestedObject.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/number_attribute.go
+++ b/internal/resource_generate/number_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -29,64 +28,22 @@ type GeneratorNumberAttribute struct {
 func (g GeneratorNumberAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/object_attribute.go
+++ b/internal/resource_generate/object_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,68 +29,25 @@ type GeneratorObjectAttribute struct {
 func (g GeneratorObjectAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	attrTypesImports := generatorschema.GetAttrTypesImports(g.CustomType, g.AttributeTypes)
-
-	imports.Add(attrTypesImports.All()...)
+	imports.Append(attrTypesImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/object_attribute_test.go
+++ b/internal/resource_generate/object_attribute_test.go
@@ -331,7 +331,7 @@ func TestGeneratorObjectAttribute_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/set_attribute.go
+++ b/internal/resource_generate/set_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,68 +29,25 @@ type GeneratorSetAttribute struct {
 func (g GeneratorSetAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	elemTypeImports := generatorschema.GetElementTypeImports(g.ElementType)
-
-	imports.Add(elemTypeImports.All()...)
+	imports.Append(elemTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports

--- a/internal/resource_generate/set_nested_attribute.go
+++ b/internal/resource_generate/set_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,114 +29,39 @@ type GeneratorSetNestedAttribute struct {
 func (g GeneratorSetNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.NestedObject.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/set_nested_block.go
+++ b/internal/resource_generate/set_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -29,108 +28,38 @@ type GeneratorSetNestedBlock struct {
 func (g GeneratorSetNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
-	if g.NestedObject.CustomType != nil {
-		if g.NestedObject.CustomType.HasImport() {
-			imports.Add(*g.NestedObject.CustomType.Import)
-		}
-	}
+	customTypeImports = generatorschema.CustomTypeImports(g.NestedObject.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.NestedObject.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.NestedObject.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.NestedObject.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.NestedObject.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/single_nested_attribute.go
+++ b/internal/resource_generate/single_nested_attribute.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,68 +29,26 @@ type GeneratorSingleNestedAttribute struct {
 func (g GeneratorSingleNestedAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
-		if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
-		}
+		customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+		imports.Append(customDefaultImports)
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/single_nested_attribute_test.go
+++ b/internal/resource_generate/single_nested_attribute_test.go
@@ -364,7 +364,7 @@ func TestGeneratorSingleNestedAttribute_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/single_nested_block.go
+++ b/internal/resource_generate/single_nested_block.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 	specschema "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -30,62 +29,25 @@ type GeneratorSingleNestedBlock struct {
 func (g GeneratorSingleNestedBlock) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	for _, v := range g.Attributes {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	for _, v := range g.Blocks {
-		imports.Add(v.Imports().All()...)
+		imports.Append(v.Imports())
 	}
 
 	return imports

--- a/internal/resource_generate/single_nested_block_test.go
+++ b/internal/resource_generate/single_nested_block_test.go
@@ -385,7 +385,7 @@ func TestGeneratorSingleNestedBlock_Imports(t *testing.T) {
 					Path: generatorschema.TypesImport,
 				},
 				{
-					Path: planModifierImport,
+					Path: generatorschema.PlanModifierImport,
 				},
 				{
 					Path: "github.com/myotherproject/myplanmodifiers/planmodifier",

--- a/internal/resource_generate/string_attribute.go
+++ b/internal/resource_generate/string_attribute.go
@@ -30,68 +30,28 @@ type GeneratorStringAttribute struct {
 func (g GeneratorStringAttribute) Imports() *generatorschema.Imports {
 	imports := generatorschema.NewImports()
 
-	if g.CustomType != nil {
-		if g.CustomType.HasImport() {
-			imports.Add(*g.CustomType.Import)
-		}
-	} else {
-		imports.Add(code.Import{
-			Path: generatorschema.TypesImport,
-		})
-	}
+	customTypeImports := generatorschema.CustomTypeImports(g.CustomType)
+	imports.Append(customTypeImports)
 
 	if g.Default != nil {
 		if g.Default.Static != nil {
 			imports.Add(code.Import{
-				Path: defaultBoolImport,
+				Path: defaultStringImport,
 			})
-		} else if g.Default.Custom != nil && g.Default.Custom.HasImport() {
-			for _, i := range g.Default.Custom.Imports {
-				if len(i.Path) > 0 {
-					imports.Add(i)
-				}
-			}
+		} else {
+			customDefaultImports := generatorschema.CustomDefaultImports(g.Default.Custom)
+			imports.Append(customDefaultImports)
 		}
 	}
 
 	for _, v := range g.PlanModifiers {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: planModifierImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customPlanModifierImports := generatorschema.CustomPlanModifierImports(v.Custom)
+		imports.Append(customPlanModifierImports)
 	}
 
 	for _, v := range g.Validators {
-		if v.Custom == nil {
-			continue
-		}
-
-		if !v.Custom.HasImport() {
-			continue
-		}
-
-		for _, i := range v.Custom.Imports {
-			if len(i.Path) > 0 {
-				imports.Add(code.Import{
-					Path: generatorschema.ValidatorImport,
-				})
-
-				imports.Add(i)
-			}
-		}
+		customValidatorImports := generatorschema.CustomValidatorImports(v.Custom)
+		imports.Append(customValidatorImports)
 	}
 
 	return imports


### PR DESCRIPTION
This PR adds reusable functions for generating imports, `CustomTypeImports()`, `CustomDefaultImports()`, `CustomPlanModifierImports()` and `CustomValidatorImports()`.

Each of the data source, provider and resource attributes and blocks have been refactored to make use of the reusable import generating functions.