### PR TITLE
Add module version for remote github install

### DIFF
--- a/cmd/tfplugingen-framework/main.go
+++ b/cmd/tfplugingen-framework/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"runtime/debug"
@@ -18,15 +19,18 @@ import (
 // https://goreleaser.com/cookbooks/using-main.version/
 func main() {
 	name := "tfplugingen-framework"
-	version := name + " commit: " + func() string {
+	version := name + func() string {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, setting := range info.Settings {
 				if setting.Key == "vcs.revision" {
-					return setting.Value
+					return fmt.Sprintf(" commit: %s", setting.Value)
 				}
 			}
+
+			return fmt.Sprintf(" module: %s", info.Main.Version)
 		}
-		return "local"
+
+		return " local"
 	}()
 
 	os.Exit(runCLI(


### PR DESCRIPTION
Looks like the `vcs.revision` tag is only applied when installed from source.

### Current behavior

```bash
# Git clone the repository
# When installing, notices the `.git` folder and stamps the binary with vcs.* tags
$ go install ./cmd/tfplugingen-framework
$ tfplugingen-framework --version

tfplugingen-framework commit: b297105d81b4365adf35f5b73d32d4f09b4d48bc

# Install from remote
$ go install github.com/hashicorp/terraform-plugin-codegen-framework/cmd/tfplugingen-framework@latest
$ tfplugingen-framework --version

tfplugingen-framework commit: local
```

Since most of our docs reference `go install github.com/hashicorp/terraform-plugin-codegen-framework/cmd/tfplugingen-framework@latest`, it might be helpful to also grab the main go module version if `vcs` info is not available.

### After changes

```bash
# Git clone the repository/PR branch
$ go install ./cmd/tfplugingen-framework
$ tfplugingen-framework --version

tfplugingen-framework commit: d7f31508fc298f42f970473574d77b0a617588b8

# Install from remote
$ go install github.com/hashicorp/terraform-plugin-codegen-framework/cmd/tfplugingen-framework@d7f31508fc298f42f970473574d77b0a617588b8
$ tfplugingen-framework --version

tfplugingen-framework module: v0.0.0-20231004113755-d7f31508fc29
```