### PR TITLE
Implement description and markdown description for provider, resource and datasource

### DIFF
--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/datasource_example/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/datasource_example/example_data_source_gen.go
@@ -561,6 +561,8 @@ func ExampleDataSourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" datasource",
+		MarkdownDescription: "\"Example\" _datasource_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/provider_example/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/provider_example/example_provider_gen.go
@@ -204,6 +204,8 @@ func ExampleProviderSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" provider",
+		MarkdownDescription: "\"Example\" _provider_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
@@ -223,6 +223,8 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" resource",
+		MarkdownDescription: "\"Example\" _resource_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_data_source_gen.go
@@ -561,6 +561,8 @@ func ExampleDataSourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" datasource",
+		MarkdownDescription: "\"Example\" _datasource_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_provider_gen.go
@@ -204,6 +204,8 @@ func ExampleProviderSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" provider",
+		MarkdownDescription: "\"Example\" _provider_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
@@ -223,6 +223,8 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" resource",
+		MarkdownDescription: "\"Example\" _resource_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/data_sources_output/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/data_sources_output/example_data_source_gen.go
@@ -561,6 +561,8 @@ func ExampleDataSourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" datasource",
+		MarkdownDescription: "\"Example\" _datasource_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/ir.json
+++ b/internal/cmd/testdata/custom_and_external/ir.json
@@ -727,7 +727,9 @@
               ]
             }
           }
-        ]
+        ],
+        "description": "\"Example\" datasource",
+        "markdown_description": "\"Example\" _datasource_"
       }
     }
   ],
@@ -1052,7 +1054,9 @@
             ]
           }
         }
-      ]
+      ],
+      "description": "\"Example\" provider",
+      "markdown_description": "\"Example\" _provider_"
     }
   },
   "resources": [
@@ -1430,7 +1434,9 @@
               ]
             }
           }
-        ]
+        ],
+        "description": "\"Example\" resource",
+        "markdown_description": "\"Example\" _resource_"
       }
     }
   ],

--- a/internal/cmd/testdata/custom_and_external/provider_output/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/provider_output/example_provider_gen.go
@@ -204,6 +204,8 @@ func ExampleProviderSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" provider",
+		MarkdownDescription: "\"Example\" _provider_",
 	}
 }
 

--- a/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
@@ -223,6 +223,8 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 		},
+		Description:         "\"Example\" resource",
+		MarkdownDescription: "\"Example\" _resource_",
 	}
 }
 

--- a/internal/datasource/convert.go
+++ b/internal/datasource/convert.go
@@ -57,6 +57,10 @@ func NewSchema(d datasource.DataSource) (generatorschema.GeneratorSchema, error)
 
 	s.Blocks = blocks
 
+	s.Description = d.Schema.Description
+
+	s.MarkdownDescription = d.Schema.MarkdownDescription
+
 	return s, nil
 }
 

--- a/internal/provider/convert.go
+++ b/internal/provider/convert.go
@@ -60,6 +60,10 @@ func NewSchema(p *provider.Provider) (generatorschema.GeneratorSchema, error) {
 
 	s.Blocks = blocks
 
+	s.Description = p.Schema.Description
+
+	s.MarkdownDescription = p.Schema.MarkdownDescription
+
 	return s, nil
 }
 

--- a/internal/resource/convert.go
+++ b/internal/resource/convert.go
@@ -57,6 +57,10 @@ func NewSchema(d resource.Resource) (generatorschema.GeneratorSchema, error) {
 
 	s.Blocks = blocks
 
+	s.Description = d.Schema.Description
+
+	s.MarkdownDescription = d.Schema.MarkdownDescription
+
 	return s, nil
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -20,8 +20,10 @@ import (
 )
 
 type GeneratorSchema struct {
-	Attributes GeneratorAttributes
-	Blocks     GeneratorBlocks
+	Attributes          GeneratorAttributes
+	Blocks              GeneratorBlocks
+	Description         *string
+	MarkdownDescription *string
 }
 
 func (g GeneratorSchema) Imports() (string, error) {
@@ -139,20 +141,34 @@ func (g GeneratorSchema) Schema(name, packageName, generatorType string) ([]byte
 		return nil, err
 	}
 
+	description := ""
+	if g.Description != nil {
+		description = *g.Description
+	}
+
+	markdownDescription := ""
+	if g.MarkdownDescription != nil {
+		markdownDescription = *g.MarkdownDescription
+	}
+
 	templateData := struct {
-		Name          string
-		PackageName   string
-		GeneratorType string
-		Attributes    string
-		Blocks        string
-		Imports       string
+		Name                string
+		PackageName         string
+		GeneratorType       string
+		Attributes          string
+		Blocks              string
+		Description         string
+		Imports             string
+		MarkdownDescription string
 	}{
-		Name:          FrameworkIdentifier(name).ToPascalCase(),
-		PackageName:   packageName,
-		GeneratorType: generatorType,
-		Attributes:    attributes,
-		Blocks:        blocks,
-		Imports:       imports,
+		Name:                FrameworkIdentifier(name).ToPascalCase(),
+		PackageName:         packageName,
+		GeneratorType:       generatorType,
+		Attributes:          attributes,
+		Blocks:              blocks,
+		Description:         description,
+		Imports:             imports,
+		MarkdownDescription: markdownDescription,
 	}
 
 	t, err := template.New("schema").Parse(SchemaGoTemplate)

--- a/internal/schema/schemas.go
+++ b/internal/schema/schemas.go
@@ -53,8 +53,10 @@ func (g GeneratorSchemas) Models() (map[string][]byte, error) {
 		var buf bytes.Buffer
 
 		generatorSchema := GeneratorSchema{
-			Attributes: schema.Attributes,
-			Blocks:     schema.Blocks,
+			Attributes:          schema.Attributes,
+			Blocks:              schema.Blocks,
+			Description:         schema.Description,
+			MarkdownDescription: schema.MarkdownDescription,
 		}
 
 		models, err := generatorSchema.Models(name)

--- a/internal/schema/templates/schema.gotmpl
+++ b/internal/schema/templates/schema.gotmpl
@@ -25,5 +25,11 @@ return schema.Schema{
         {{- .Blocks}}
 	},
     {{- end}}
+    {{- if .Description }}
+	Description: {{printf "%q" .Description}},
+    {{- end}}
+    {{- if .MarkdownDescription }}
+	MarkdownDescription: {{printf "%q" .MarkdownDescription}},
+    {{- end}}
     }
 }


### PR DESCRIPTION
Hi there, I took a super quick swing at supporting "description" and "markdown_description" in schema generation for providers, resources and data sources.

I couldn't see an existing test asserting this generation output, but I saw one specifically for models and cribbed this test from that. Apart from the tests introduced here, I've run this successfully on a provider I'm writing.

As I say, this was super quick so feel free to dismiss or provide absolutely any level of feedback. 🙂

Partially addresses #112
