### PR TITLE
Fix `ToObjectValue` function for nested objects for null or unknown value states

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240514-143136.yaml
+++ b/.changes/unreleased/BUG FIXES-20240514-143136.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix ToObjectValue function for nested objects for null or unknown values
+time: 2024-05-14T14:31:36.35397+02:00
+custom:
+    Issue: "138"

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/datasource_example/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/datasource_example/example_data_source_gen.go
@@ -1063,11 +1063,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1411,11 +1411,11 @@ func (v ListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetyp
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1768,11 +1768,11 @@ func (v ListNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (baset
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2110,11 +2110,11 @@ func (v ListNestedAttributeThreeListNestedAttributeOneValue) ToObjectValue(ctx c
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2469,11 +2469,11 @@ func (v ListNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (basetyp
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2795,11 +2795,11 @@ func (v ListNestedAttributeTwoListNestedAttributeOneValue) ToObjectValue(ctx con
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3315,11 +3315,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3859,11 +3859,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -4403,11 +4403,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -4751,11 +4751,11 @@ func (v SingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (baset
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5100,11 +5100,11 @@ func (v SingleNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (bas
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5442,11 +5442,11 @@ func (v SingleNestedAttributeThreeSingleNestedAttributeOneValue) ToObjectValue(c
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5793,11 +5793,11 @@ func (v SingleNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (baset
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6119,11 +6119,11 @@ func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) ToObjectValue(ctx
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6639,11 +6639,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6987,11 +6987,11 @@ func (v ListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.O
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -7414,11 +7414,11 @@ func (v ListNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetypes
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -7766,11 +7766,11 @@ func (v ListNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context.C
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8125,11 +8125,11 @@ func (v ListNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes.O
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8451,11 +8451,11 @@ func (v ListNestedBlockTwoListNestedBlockOneValue) ToObjectValue(ctx context.Con
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8971,11 +8971,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -9515,11 +9515,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -9863,11 +9863,11 @@ func (v SingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10290,11 +10290,11 @@ func (v SingleNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetyp
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10642,11 +10642,11 @@ func (v SingleNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10993,11 +10993,11 @@ func (v SingleNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -11319,11 +11319,11 @@ func (v SingleNestedBlockTwoSingleNestedBlockOneValue) ToObjectValue(ctx context
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/datasource_example/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/datasource_example/example_data_source_gen.go
@@ -1055,14 +1055,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1397,10 +1407,20 @@ func (v ListNestedAttributeOneValue) String() string {
 func (v ListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -1742,12 +1762,22 @@ func (v ListNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (baset
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_attribute_three_list_nested_attribute_one": basetypes.ListType{
-				ElemType: ListNestedAttributeThreeListNestedAttributeOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_attribute_three_list_nested_attribute_one": basetypes.ListType{
+			ElemType: ListNestedAttributeThreeListNestedAttributeOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_attribute_three_list_nested_attribute_one": listNestedAttributeThreeListNestedAttributeOne,
 		})
@@ -2074,12 +2104,22 @@ func (v ListNestedAttributeThreeListNestedAttributeOneValue) ToObjectValue(ctx c
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -2423,12 +2463,22 @@ func (v ListNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (basetyp
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_attribute_two_list_nested_attribute_one": basetypes.ListType{
-				ElemType: ListNestedAttributeTwoListNestedAttributeOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_attribute_two_list_nested_attribute_one": basetypes.ListType{
+			ElemType: ListNestedAttributeTwoListNestedAttributeOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_attribute_two_list_nested_attribute_one": listNestedAttributeTwoListNestedAttributeOne,
 		})
@@ -2741,10 +2791,20 @@ func (v ListNestedAttributeTwoListNestedAttributeOneValue) String() string {
 func (v ListNestedAttributeTwoListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -3247,14 +3307,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3781,14 +3851,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -4315,14 +4395,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -4657,10 +4747,20 @@ func (v SingleNestedAttributeOneValue) String() string {
 func (v SingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -4994,12 +5094,22 @@ func (v SingleNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (bas
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_attribute_three_single_nested_attribute_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedAttributeThreeSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_attribute_three_single_nested_attribute_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedAttributeThreeSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_attribute_three_single_nested_attribute_one": singleNestedAttributeThreeSingleNestedAttributeOne,
 		})
@@ -5326,12 +5436,22 @@ func (v SingleNestedAttributeThreeSingleNestedAttributeOneValue) ToObjectValue(c
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -5667,12 +5787,22 @@ func (v SingleNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (baset
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_attribute_two_single_nested_attribute_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedAttributeTwoSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_attribute_two_single_nested_attribute_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedAttributeTwoSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_attribute_two_single_nested_attribute_one": singleNestedAttributeTwoSingleNestedAttributeOne,
 		})
@@ -5985,10 +6115,20 @@ func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) String() string {
 func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -6491,14 +6631,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -6833,10 +6983,20 @@ func (v ListNestedBlockOneValue) String() string {
 func (v ListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -7245,15 +7405,25 @@ func (v ListNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetypes
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_block_three_list_nested_block_one": basetypes.ListType{
-				ElemType: ListNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
-			},
-			"object_attribute": basetypes.ObjectType{
-				AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_block_three_list_nested_block_one": basetypes.ListType{
+			ElemType: ListNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
 		},
+		"object_attribute": basetypes.ObjectType{
+			AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
+		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_block_three_list_nested_block_one": listNestedBlockThreeListNestedBlockOne,
 			"object_attribute": objectAttributeVal,
@@ -7590,12 +7760,22 @@ func (v ListNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context.C
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -7939,12 +8119,22 @@ func (v ListNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes.O
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_block_two_list_nested_block_one": basetypes.ListType{
-				ElemType: ListNestedBlockTwoListNestedBlockOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_block_two_list_nested_block_one": basetypes.ListType{
+			ElemType: ListNestedBlockTwoListNestedBlockOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_block_two_list_nested_block_one": listNestedBlockTwoListNestedBlockOne,
 		})
@@ -8257,10 +8447,20 @@ func (v ListNestedBlockTwoListNestedBlockOneValue) String() string {
 func (v ListNestedBlockTwoListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -8763,14 +8963,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -9297,14 +9507,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -9639,10 +9859,20 @@ func (v SingleNestedBlockOneValue) String() string {
 func (v SingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -10051,15 +10281,25 @@ func (v SingleNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetyp
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"object_attribute": basetypes.ObjectType{
-				AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
-			},
-			"single_nested_block_three_list_nested_block_one": basetypes.ListType{
-				ElemType: SingleNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"object_attribute": basetypes.ObjectType{
+			AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
 		},
+		"single_nested_block_three_list_nested_block_one": basetypes.ListType{
+			ElemType: SingleNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
+		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"object_attribute": objectAttributeVal,
 			"single_nested_block_three_list_nested_block_one": singleNestedBlockThreeListNestedBlockOne,
@@ -10396,12 +10636,22 @@ func (v SingleNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -10737,12 +10987,22 @@ func (v SingleNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_block_two_single_nested_block_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedBlockTwoSingleNestedBlockOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_block_two_single_nested_block_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedBlockTwoSingleNestedBlockOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_block_two_single_nested_block_one": singleNestedBlockTwoSingleNestedBlockOne,
 		})
@@ -11055,10 +11315,20 @@ func (v SingleNestedBlockTwoSingleNestedBlockOneValue) String() string {
 func (v SingleNestedBlockTwoSingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/provider_example/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/provider_example/example_provider_gen.go
@@ -686,11 +686,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1230,11 +1230,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1774,11 +1774,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2318,11 +2318,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2862,11 +2862,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3406,11 +3406,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3950,11 +3950,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/provider_example/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/provider_example/example_provider_gen.go
@@ -678,14 +678,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1212,14 +1222,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1746,14 +1766,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2280,14 +2310,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2814,14 +2854,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3348,14 +3398,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3882,14 +3942,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
@@ -706,11 +706,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1250,11 +1250,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1794,11 +1794,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2338,11 +2338,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2882,11 +2882,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3426,11 +3426,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3970,11 +3970,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
@@ -698,14 +698,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1232,14 +1242,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1766,14 +1786,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2300,14 +2330,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2834,14 +2874,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3368,14 +3418,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3902,14 +3962,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_data_source_gen.go
@@ -1063,11 +1063,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1411,11 +1411,11 @@ func (v ListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetyp
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1768,11 +1768,11 @@ func (v ListNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (baset
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2110,11 +2110,11 @@ func (v ListNestedAttributeThreeListNestedAttributeOneValue) ToObjectValue(ctx c
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2469,11 +2469,11 @@ func (v ListNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (basetyp
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2795,11 +2795,11 @@ func (v ListNestedAttributeTwoListNestedAttributeOneValue) ToObjectValue(ctx con
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3315,11 +3315,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3859,11 +3859,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -4403,11 +4403,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -4751,11 +4751,11 @@ func (v SingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (baset
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5100,11 +5100,11 @@ func (v SingleNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (bas
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5442,11 +5442,11 @@ func (v SingleNestedAttributeThreeSingleNestedAttributeOneValue) ToObjectValue(c
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5793,11 +5793,11 @@ func (v SingleNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (baset
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6119,11 +6119,11 @@ func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) ToObjectValue(ctx
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6639,11 +6639,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6987,11 +6987,11 @@ func (v ListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.O
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -7414,11 +7414,11 @@ func (v ListNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetypes
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -7766,11 +7766,11 @@ func (v ListNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context.C
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8125,11 +8125,11 @@ func (v ListNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes.O
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8451,11 +8451,11 @@ func (v ListNestedBlockTwoListNestedBlockOneValue) ToObjectValue(ctx context.Con
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8971,11 +8971,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -9515,11 +9515,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -9863,11 +9863,11 @@ func (v SingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10290,11 +10290,11 @@ func (v SingleNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetyp
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10642,11 +10642,11 @@ func (v SingleNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10993,11 +10993,11 @@ func (v SingleNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -11319,11 +11319,11 @@ func (v SingleNestedBlockTwoSingleNestedBlockOneValue) ToObjectValue(ctx context
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_data_source_gen.go
@@ -1055,14 +1055,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1397,10 +1407,20 @@ func (v ListNestedAttributeOneValue) String() string {
 func (v ListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -1742,12 +1762,22 @@ func (v ListNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (baset
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_attribute_three_list_nested_attribute_one": basetypes.ListType{
-				ElemType: ListNestedAttributeThreeListNestedAttributeOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_attribute_three_list_nested_attribute_one": basetypes.ListType{
+			ElemType: ListNestedAttributeThreeListNestedAttributeOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_attribute_three_list_nested_attribute_one": listNestedAttributeThreeListNestedAttributeOne,
 		})
@@ -2074,12 +2104,22 @@ func (v ListNestedAttributeThreeListNestedAttributeOneValue) ToObjectValue(ctx c
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -2423,12 +2463,22 @@ func (v ListNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (basetyp
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_attribute_two_list_nested_attribute_one": basetypes.ListType{
-				ElemType: ListNestedAttributeTwoListNestedAttributeOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_attribute_two_list_nested_attribute_one": basetypes.ListType{
+			ElemType: ListNestedAttributeTwoListNestedAttributeOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_attribute_two_list_nested_attribute_one": listNestedAttributeTwoListNestedAttributeOne,
 		})
@@ -2741,10 +2791,20 @@ func (v ListNestedAttributeTwoListNestedAttributeOneValue) String() string {
 func (v ListNestedAttributeTwoListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -3247,14 +3307,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3781,14 +3851,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -4315,14 +4395,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -4657,10 +4747,20 @@ func (v SingleNestedAttributeOneValue) String() string {
 func (v SingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -4994,12 +5094,22 @@ func (v SingleNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (bas
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_attribute_three_single_nested_attribute_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedAttributeThreeSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_attribute_three_single_nested_attribute_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedAttributeThreeSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_attribute_three_single_nested_attribute_one": singleNestedAttributeThreeSingleNestedAttributeOne,
 		})
@@ -5326,12 +5436,22 @@ func (v SingleNestedAttributeThreeSingleNestedAttributeOneValue) ToObjectValue(c
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -5667,12 +5787,22 @@ func (v SingleNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (baset
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_attribute_two_single_nested_attribute_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedAttributeTwoSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_attribute_two_single_nested_attribute_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedAttributeTwoSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_attribute_two_single_nested_attribute_one": singleNestedAttributeTwoSingleNestedAttributeOne,
 		})
@@ -5985,10 +6115,20 @@ func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) String() string {
 func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -6491,14 +6631,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -6833,10 +6983,20 @@ func (v ListNestedBlockOneValue) String() string {
 func (v ListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -7245,15 +7405,25 @@ func (v ListNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetypes
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_block_three_list_nested_block_one": basetypes.ListType{
-				ElemType: ListNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
-			},
-			"object_attribute": basetypes.ObjectType{
-				AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_block_three_list_nested_block_one": basetypes.ListType{
+			ElemType: ListNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
 		},
+		"object_attribute": basetypes.ObjectType{
+			AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
+		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_block_three_list_nested_block_one": listNestedBlockThreeListNestedBlockOne,
 			"object_attribute": objectAttributeVal,
@@ -7590,12 +7760,22 @@ func (v ListNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context.C
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -7939,12 +8119,22 @@ func (v ListNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes.O
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_block_two_list_nested_block_one": basetypes.ListType{
-				ElemType: ListNestedBlockTwoListNestedBlockOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_block_two_list_nested_block_one": basetypes.ListType{
+			ElemType: ListNestedBlockTwoListNestedBlockOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_block_two_list_nested_block_one": listNestedBlockTwoListNestedBlockOne,
 		})
@@ -8257,10 +8447,20 @@ func (v ListNestedBlockTwoListNestedBlockOneValue) String() string {
 func (v ListNestedBlockTwoListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -8763,14 +8963,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -9297,14 +9507,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -9639,10 +9859,20 @@ func (v SingleNestedBlockOneValue) String() string {
 func (v SingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -10051,15 +10281,25 @@ func (v SingleNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetyp
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"object_attribute": basetypes.ObjectType{
-				AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
-			},
-			"single_nested_block_three_list_nested_block_one": basetypes.ListType{
-				ElemType: SingleNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"object_attribute": basetypes.ObjectType{
+			AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
 		},
+		"single_nested_block_three_list_nested_block_one": basetypes.ListType{
+			ElemType: SingleNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
+		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"object_attribute": objectAttributeVal,
 			"single_nested_block_three_list_nested_block_one": singleNestedBlockThreeListNestedBlockOne,
@@ -10396,12 +10636,22 @@ func (v SingleNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -10737,12 +10987,22 @@ func (v SingleNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_block_two_single_nested_block_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedBlockTwoSingleNestedBlockOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_block_two_single_nested_block_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedBlockTwoSingleNestedBlockOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_block_two_single_nested_block_one": singleNestedBlockTwoSingleNestedBlockOne,
 		})
@@ -11055,10 +11315,20 @@ func (v SingleNestedBlockTwoSingleNestedBlockOneValue) String() string {
 func (v SingleNestedBlockTwoSingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_provider_gen.go
@@ -686,11 +686,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1230,11 +1230,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1774,11 +1774,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2318,11 +2318,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2862,11 +2862,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3406,11 +3406,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3950,11 +3950,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_provider_gen.go
@@ -678,14 +678,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1212,14 +1222,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1746,14 +1766,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2280,14 +2310,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2814,14 +2854,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3348,14 +3398,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3882,14 +3942,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
@@ -706,11 +706,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1250,11 +1250,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1794,11 +1794,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2338,11 +2338,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2882,11 +2882,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3426,11 +3426,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3970,11 +3970,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
@@ -698,14 +698,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1232,14 +1242,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1766,14 +1786,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2300,14 +2330,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2834,14 +2874,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3368,14 +3418,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3902,14 +3962,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,

--- a/internal/cmd/testdata/custom_and_external/data_sources_output/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/data_sources_output/example_data_source_gen.go
@@ -1063,11 +1063,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1411,11 +1411,11 @@ func (v ListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetyp
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1768,11 +1768,11 @@ func (v ListNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (baset
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2110,11 +2110,11 @@ func (v ListNestedAttributeThreeListNestedAttributeOneValue) ToObjectValue(ctx c
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2469,11 +2469,11 @@ func (v ListNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (basetyp
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2795,11 +2795,11 @@ func (v ListNestedAttributeTwoListNestedAttributeOneValue) ToObjectValue(ctx con
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3315,11 +3315,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3859,11 +3859,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -4403,11 +4403,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -4751,11 +4751,11 @@ func (v SingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (baset
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5100,11 +5100,11 @@ func (v SingleNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (bas
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5442,11 +5442,11 @@ func (v SingleNestedAttributeThreeSingleNestedAttributeOneValue) ToObjectValue(c
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -5793,11 +5793,11 @@ func (v SingleNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (baset
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6119,11 +6119,11 @@ func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) ToObjectValue(ctx
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6639,11 +6639,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -6987,11 +6987,11 @@ func (v ListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.O
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -7414,11 +7414,11 @@ func (v ListNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetypes
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -7766,11 +7766,11 @@ func (v ListNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context.C
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8125,11 +8125,11 @@ func (v ListNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes.O
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8451,11 +8451,11 @@ func (v ListNestedBlockTwoListNestedBlockOneValue) ToObjectValue(ctx context.Con
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -8971,11 +8971,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -9515,11 +9515,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -9863,11 +9863,11 @@ func (v SingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10290,11 +10290,11 @@ func (v SingleNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetyp
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10642,11 +10642,11 @@ func (v SingleNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -10993,11 +10993,11 @@ func (v SingleNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes
 		},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -11319,11 +11319,11 @@ func (v SingleNestedBlockTwoSingleNestedBlockOneValue) ToObjectValue(ctx context
 		"bool_attribute": basetypes.BoolType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/data_sources_output/example_data_source_gen.go
+++ b/internal/cmd/testdata/custom_and_external/data_sources_output/example_data_source_gen.go
@@ -1055,14 +1055,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1397,10 +1407,20 @@ func (v ListNestedAttributeOneValue) String() string {
 func (v ListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -1742,12 +1762,22 @@ func (v ListNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (baset
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_attribute_three_list_nested_attribute_one": basetypes.ListType{
-				ElemType: ListNestedAttributeThreeListNestedAttributeOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_attribute_three_list_nested_attribute_one": basetypes.ListType{
+			ElemType: ListNestedAttributeThreeListNestedAttributeOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_attribute_three_list_nested_attribute_one": listNestedAttributeThreeListNestedAttributeOne,
 		})
@@ -2074,12 +2104,22 @@ func (v ListNestedAttributeThreeListNestedAttributeOneValue) ToObjectValue(ctx c
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -2423,12 +2463,22 @@ func (v ListNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (basetyp
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_attribute_two_list_nested_attribute_one": basetypes.ListType{
-				ElemType: ListNestedAttributeTwoListNestedAttributeOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_attribute_two_list_nested_attribute_one": basetypes.ListType{
+			ElemType: ListNestedAttributeTwoListNestedAttributeOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_attribute_two_list_nested_attribute_one": listNestedAttributeTwoListNestedAttributeOne,
 		})
@@ -2741,10 +2791,20 @@ func (v ListNestedAttributeTwoListNestedAttributeOneValue) String() string {
 func (v ListNestedAttributeTwoListNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -3247,14 +3307,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3781,14 +3851,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -4315,14 +4395,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -4657,10 +4747,20 @@ func (v SingleNestedAttributeOneValue) String() string {
 func (v SingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -4994,12 +5094,22 @@ func (v SingleNestedAttributeThreeValue) ToObjectValue(ctx context.Context) (bas
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_attribute_three_single_nested_attribute_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedAttributeThreeSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_attribute_three_single_nested_attribute_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedAttributeThreeSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_attribute_three_single_nested_attribute_one": singleNestedAttributeThreeSingleNestedAttributeOne,
 		})
@@ -5326,12 +5436,22 @@ func (v SingleNestedAttributeThreeSingleNestedAttributeOneValue) ToObjectValue(c
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -5667,12 +5787,22 @@ func (v SingleNestedAttributeTwoValue) ToObjectValue(ctx context.Context) (baset
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_attribute_two_single_nested_attribute_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedAttributeTwoSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_attribute_two_single_nested_attribute_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedAttributeTwoSingleNestedAttributeOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_attribute_two_single_nested_attribute_one": singleNestedAttributeTwoSingleNestedAttributeOne,
 		})
@@ -5985,10 +6115,20 @@ func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) String() string {
 func (v SingleNestedAttributeTwoSingleNestedAttributeOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -6491,14 +6631,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -6833,10 +6983,20 @@ func (v ListNestedBlockOneValue) String() string {
 func (v ListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -7245,15 +7405,25 @@ func (v ListNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetypes
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_block_three_list_nested_block_one": basetypes.ListType{
-				ElemType: ListNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
-			},
-			"object_attribute": basetypes.ObjectType{
-				AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_block_three_list_nested_block_one": basetypes.ListType{
+			ElemType: ListNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
 		},
+		"object_attribute": basetypes.ObjectType{
+			AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
+		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_block_three_list_nested_block_one": listNestedBlockThreeListNestedBlockOne,
 			"object_attribute": objectAttributeVal,
@@ -7590,12 +7760,22 @@ func (v ListNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context.C
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -7939,12 +8119,22 @@ func (v ListNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes.O
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_nested_block_two_list_nested_block_one": basetypes.ListType{
-				ElemType: ListNestedBlockTwoListNestedBlockOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_nested_block_two_list_nested_block_one": basetypes.ListType{
+			ElemType: ListNestedBlockTwoListNestedBlockOneValue{}.Type(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_nested_block_two_list_nested_block_one": listNestedBlockTwoListNestedBlockOne,
 		})
@@ -8257,10 +8447,20 @@ func (v ListNestedBlockTwoListNestedBlockOneValue) String() string {
 func (v ListNestedBlockTwoListNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -8763,14 +8963,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -9297,14 +9507,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -9639,10 +9859,20 @@ func (v SingleNestedBlockOneValue) String() string {
 func (v SingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})
@@ -10051,15 +10281,25 @@ func (v SingleNestedBlockThreeValue) ToObjectValue(ctx context.Context) (basetyp
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"object_attribute": basetypes.ObjectType{
-				AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
-			},
-			"single_nested_block_three_list_nested_block_one": basetypes.ListType{
-				ElemType: SingleNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"object_attribute": basetypes.ObjectType{
+			AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
 		},
+		"single_nested_block_three_list_nested_block_one": basetypes.ListType{
+			ElemType: SingleNestedBlockThreeListNestedBlockOneValue{}.Type(ctx),
+		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"object_attribute": objectAttributeVal,
 			"single_nested_block_three_list_nested_block_one": singleNestedBlockThreeListNestedBlockOne,
@@ -10396,12 +10636,22 @@ func (v SingleNestedBlockThreeListNestedBlockOneValue) ToObjectValue(ctx context
 		}), diags
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"list_attribute": basetypes.ListType{
-				ElemType: types.StringType,
-			},
+	attributeTypes := map[string]attr.Type{
+		"list_attribute": basetypes.ListType{
+			ElemType: types.StringType,
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"list_attribute": listAttributeVal,
 		})
@@ -10737,12 +10987,22 @@ func (v SingleNestedBlockTwoValue) ToObjectValue(ctx context.Context) (basetypes
 		)
 	}
 
-	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"single_nested_block_two_single_nested_block_one": basetypes.ObjectType{
-				AttrTypes: SingleNestedBlockTwoSingleNestedBlockOneValue{}.AttributeTypes(ctx),
-			},
+	attributeTypes := map[string]attr.Type{
+		"single_nested_block_two_single_nested_block_one": basetypes.ObjectType{
+			AttrTypes: SingleNestedBlockTwoSingleNestedBlockOneValue{}.AttributeTypes(ctx),
 		},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
 		map[string]attr.Value{
 			"single_nested_block_two_single_nested_block_one": singleNestedBlockTwoSingleNestedBlockOne,
 		})
@@ -11055,10 +11315,20 @@ func (v SingleNestedBlockTwoSingleNestedBlockOneValue) String() string {
 func (v SingleNestedBlockTwoSingleNestedBlockOneValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute": basetypes.BoolType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute": basetypes.BoolType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute": v.BoolAttribute,
 		})

--- a/internal/cmd/testdata/custom_and_external/provider_output/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/provider_output/example_provider_gen.go
@@ -686,11 +686,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1230,11 +1230,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1774,11 +1774,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2318,11 +2318,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2862,11 +2862,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3406,11 +3406,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3950,11 +3950,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/provider_output/example_provider_gen.go
+++ b/internal/cmd/testdata/custom_and_external/provider_output/example_provider_gen.go
@@ -678,14 +678,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1212,14 +1222,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1746,14 +1766,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2280,14 +2310,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2814,14 +2854,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3348,14 +3398,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3882,14 +3942,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,

--- a/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
@@ -706,11 +706,11 @@ func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context)
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1250,11 +1250,11 @@ func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -1794,11 +1794,11 @@ func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) 
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2338,11 +2338,11 @@ func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Contex
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -2882,11 +2882,11 @@ func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (ba
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3426,11 +3426,11 @@ func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (bas
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 
@@ -3970,11 +3970,11 @@ func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (
 		"string_attribute":  basetypes.StringType{},
 	}
 
-	if v.state == attr.ValueStateNull {
+	if v.IsNull() {
 		return types.ObjectNull(attributeTypes), diags
 	}
 
-	if v.state == attr.ValueStateUnknown {
+	if v.IsUnknown() {
 		return types.ObjectUnknown(attributeTypes), diags
 	}
 

--- a/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
@@ -698,14 +698,24 @@ func (v ListNestedAttributeAssocExtTypeValue) String() string {
 func (v ListNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1232,14 +1242,24 @@ func (v MapNestedAttributeAssocExtTypeValue) String() string {
 func (v MapNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -1766,14 +1786,24 @@ func (v SetNestedAttributeAssocExtTypeValue) String() string {
 func (v SetNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2300,14 +2330,24 @@ func (v SingleNestedAttributeAssocExtTypeValue) String() string {
 func (v SingleNestedAttributeAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -2834,14 +2874,24 @@ func (v ListNestedBlockAssocExtTypeValue) String() string {
 func (v ListNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3368,14 +3418,24 @@ func (v SetNestedBlockAssocExtTypeValue) String() string {
 func (v SetNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,
@@ -3902,14 +3962,24 @@ func (v SingleNestedBlockAssocExtTypeValue) String() string {
 func (v SingleNestedBlockAssocExtTypeValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	attributeTypes := map[string]attr.Type{
+		"bool_attribute":    basetypes.BoolType{},
+		"float64_attribute": basetypes.Float64Type{},
+		"int64_attribute":   basetypes.Int64Type{},
+		"number_attribute":  basetypes.NumberType{},
+		"string_attribute":  basetypes.StringType{},
+	}
+
+	if v.state == attr.ValueStateNull {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.state == attr.ValueStateUnknown {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
 	objVal, diags := types.ObjectValue(
-		map[string]attr.Type{
-			"bool_attribute":    basetypes.BoolType{},
-			"float64_attribute": basetypes.Float64Type{},
-			"int64_attribute":   basetypes.Int64Type{},
-			"number_attribute":  basetypes.NumberType{},
-			"string_attribute":  basetypes.StringType{},
-		},
+		attributeTypes,
 		map[string]attr.Value{
 			"bool_attribute":    v.BoolAttribute,
 			"float64_attribute": v.Float64Attribute,

--- a/internal/schema/custom_nested_object_test.go
+++ b/internal/schema/custom_nested_object_test.go
@@ -1019,10 +1019,20 @@ func TestCustomNestedObjectValue_renderToObjectValue(t *testing.T) {
 func (v ExampleValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 var diags diag.Diagnostics
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "bool_attribute": basetypes.BoolType{},
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "bool_attribute": v.BoolAttribute,
 })
@@ -1072,10 +1082,20 @@ AttrTypes: ListNestedAttributeValue{}.AttributeTypes(ctx),
 }
 
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "list_nested_attribute": basetypes.ListType{},
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "list_nested_attribute": listNestedAttribute,
 })
@@ -1125,10 +1145,20 @@ AttrTypes: MapNestedAttributeValue{}.AttributeTypes(ctx),
 }
 
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "map_nested_attribute": basetypes.MapType{},
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "map_nested_attribute": mapNestedAttribute,
 })
@@ -1178,10 +1208,20 @@ AttrTypes: SetNestedAttributeValue{}.AttributeTypes(ctx),
 }
 
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "set_nested_attribute": basetypes.SetType{},
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "set_nested_attribute": setNestedAttribute,
 })
@@ -1201,10 +1241,20 @@ return objVal, diags
 func (v ExampleValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
 var diags diag.Diagnostics
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "type": basetypes.BoolType{},
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "type": v.ExampleType,
 })
@@ -1254,10 +1304,20 @@ AttrTypes: TypeValue{}.AttributeTypes(ctx),
 }
 
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "type": basetypes.ListType{},
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "type": exampleType,
 })
@@ -1295,12 +1355,22 @@ ElemType: types.BoolType,
 }), diags
 }
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "list_attribute": basetypes.ListType{
 ElemType: types.BoolType,
 },
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "list_attribute": listAttributeVal,
 })
@@ -1338,12 +1408,22 @@ ElemType: types.BoolType,
 }), diags
 }
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "type": basetypes.ListType{
 ElemType: types.BoolType,
 },
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "type": typeVal,
 })
@@ -1375,12 +1455,22 @@ AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
 }), diags
 }
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "object_attribute": basetypes.ObjectType{
 AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
 },
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "object_attribute": objectAttributeVal,
 })
@@ -1412,12 +1502,22 @@ AttrTypes: v.ExampleType.AttributeTypes(ctx),
 }), diags
 }
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 "type": basetypes.ObjectType{
 AttrTypes: v.ExampleType.AttributeTypes(ctx),
 },
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 "type": typeVal,
 })

--- a/internal/schema/custom_nested_object_test.go
+++ b/internal/schema/custom_nested_object_test.go
@@ -1023,11 +1023,11 @@ attributeTypes := map[string]attr.Type{
 "bool_attribute": basetypes.BoolType{},
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1086,11 +1086,11 @@ attributeTypes := map[string]attr.Type{
 "list_nested_attribute": basetypes.ListType{},
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1149,11 +1149,11 @@ attributeTypes := map[string]attr.Type{
 "map_nested_attribute": basetypes.MapType{},
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1212,11 +1212,11 @@ attributeTypes := map[string]attr.Type{
 "set_nested_attribute": basetypes.SetType{},
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1245,11 +1245,11 @@ attributeTypes := map[string]attr.Type{
 "type": basetypes.BoolType{},
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1308,11 +1308,11 @@ attributeTypes := map[string]attr.Type{
 "type": basetypes.ListType{},
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1361,11 +1361,11 @@ ElemType: types.BoolType,
 },
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1414,11 +1414,11 @@ ElemType: types.BoolType,
 },
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1461,11 +1461,11 @@ AttrTypes: v.ObjectAttribute.AttributeTypes(ctx),
 },
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 
@@ -1508,11 +1508,11 @@ AttrTypes: v.ExampleType.AttributeTypes(ctx),
 },
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 

--- a/internal/schema/templates/nested_object_value_to_object_value.gotmpl
+++ b/internal/schema/templates/nested_object_value_to_object_value.gotmpl
@@ -100,8 +100,7 @@ AttrTypes: v.{{$key.ToPrefixPascalCase $.Name}}.AttributeTypes(ctx),
 {{- end}}
 {{- end}}
 
-objVal, diags := types.ObjectValue(
-map[string]attr.Type{
+attributeTypes := map[string]attr.Type{
 {{- range $key, $value := .AttributeTypes }}
 {{- if eq $value "Object"}}
 "{{$key}}": basetypes.ObjectType{
@@ -111,7 +110,18 @@ AttrTypes: v.{{$key.ToPrefixPascalCase $.Name}}.AttributeTypes(ctx),
 "{{$key}}": {{index $.AttrTypes $key}},
 {{- end}}
 {{- end}}
-},
+}
+
+if v.state == attr.ValueStateNull {
+return types.ObjectNull(attributeTypes), diags
+}
+
+if v.state == attr.ValueStateUnknown {
+return types.ObjectUnknown(attributeTypes), diags
+}
+
+objVal, diags := types.ObjectValue(
+attributeTypes,
 map[string]attr.Value{
 {{- range $key, $value := .AttributeTypes }}
 {{- if eq $value "ListNested" "MapNested" "SetNested" "SingleNested"}}

--- a/internal/schema/templates/nested_object_value_to_object_value.gotmpl
+++ b/internal/schema/templates/nested_object_value_to_object_value.gotmpl
@@ -112,11 +112,11 @@ AttrTypes: v.{{$key.ToPrefixPascalCase $.Name}}.AttributeTypes(ctx),
 {{- end}}
 }
 
-if v.state == attr.ValueStateNull {
+if v.IsNull() {
 return types.ObjectNull(attributeTypes), diags
 }
 
-if v.state == attr.ValueStateUnknown {
+if v.IsUnknown() {
 return types.ObjectUnknown(attributeTypes), diags
 }
 


### PR DESCRIPTION
Previously the generated code would still return data in these two cases making it
impossible to leave out configuration for optional attributes that contained required
fields within.
