### PR TITLE
Chore: golangci-lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
   exclude-dirs:
     - output
@@ -7,9 +7,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -20,11 +20,11 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
     - govet
+    - usetesting
 
 run:
   # Prevent false positive timeouts in CI

--- a/internal/cmd/generate_all_test.go
+++ b/internal/cmd/generate_all_test.go
@@ -30,7 +30,7 @@ func TestGenerateAllCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/generate_data_sources_test.go
+++ b/internal/cmd/generate_data_sources_test.go
@@ -23,7 +23,7 @@ func TestGenerateDataSourcesCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/generate_provider_test.go
+++ b/internal/cmd/generate_provider_test.go
@@ -27,7 +27,7 @@ func TestGenerateProviderCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/generate_resources_test.go
+++ b/internal/cmd/generate_resources_test.go
@@ -23,7 +23,7 @@ func TestGenerateResourcesCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/scaffold_data_source_test.go
+++ b/internal/cmd/scaffold_data_source_test.go
@@ -21,7 +21,7 @@ func TestScaffoldDataSourceCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/scaffold_provider_test.go
+++ b/internal/cmd/scaffold_provider_test.go
@@ -21,7 +21,7 @@ func TestScaffoldProviderCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/scaffold_resource_test.go
+++ b/internal/cmd/scaffold_resource_test.go
@@ -21,7 +21,7 @@ func TestScaffoldResourceCommand(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/datasource/bool_attribute_test.go
+++ b/internal/datasource/bool_attribute_test.go
@@ -151,7 +151,6 @@ func TestGeneratorBoolAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -404,7 +403,6 @@ func TestGeneratorBoolAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -557,7 +555,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -643,7 +640,6 @@ func TestGeneratorBoolAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/convert_test.go
+++ b/internal/datasource/convert_test.go
@@ -428,7 +428,6 @@ func Test_NewSchemas(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/float64_attribute_test.go
+++ b/internal/datasource/float64_attribute_test.go
@@ -150,7 +150,6 @@ func TestGeneratorFloat64Attribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -306,7 +305,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -392,7 +390,6 @@ func TestGeneratorFloat64Attribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/int64_attribute_test.go
+++ b/internal/datasource/int64_attribute_test.go
@@ -150,7 +150,6 @@ func TestGeneratorInt64Attribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -307,7 +306,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -393,7 +391,6 @@ func TestGeneratorInt64Attribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/list_attribute_test.go
+++ b/internal/datasource/list_attribute_test.go
@@ -558,7 +558,6 @@ func TestGeneratorListAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1001,7 +1000,6 @@ func TestGeneratorListAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1593,7 +1591,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1685,7 +1682,6 @@ func TestGeneratorListAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/list_nested_attribute_test.go
+++ b/internal/datasource/list_nested_attribute_test.go
@@ -562,7 +562,6 @@ func TestGeneratorListNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1184,7 +1183,6 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1660,7 +1658,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1710,7 +1707,6 @@ func TestGeneratorListNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/list_nested_block_test.go
+++ b/internal/datasource/list_nested_block_test.go
@@ -630,7 +630,6 @@ func TestGeneratorListNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1302,7 +1301,6 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1777,7 +1775,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1827,7 +1824,6 @@ func TestGeneratorListNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/map_attribute_test.go
+++ b/internal/datasource/map_attribute_test.go
@@ -557,7 +557,6 @@ func TestGeneratorMapAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1153,7 +1152,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1245,7 +1243,6 @@ func TestGeneratorMapAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/map_nested_attribute_test.go
+++ b/internal/datasource/map_nested_attribute_test.go
@@ -562,7 +562,6 @@ func TestGeneratorMapNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1184,7 +1183,6 @@ func TestGeneratorMapNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1660,7 +1658,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1710,7 +1707,6 @@ func TestGeneratorMapNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/number_attribute_test.go
+++ b/internal/datasource/number_attribute_test.go
@@ -150,7 +150,6 @@ func TestGeneratorNumberAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -307,7 +306,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -393,7 +391,6 @@ func TestGeneratorNumberAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/object_attribute_test.go
+++ b/internal/datasource/object_attribute_test.go
@@ -402,7 +402,6 @@ func TestGeneratorObjectAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -848,7 +847,6 @@ func TestGeneratorObjectAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1619,7 +1617,6 @@ AttributeTypes: map[string]attr.Type{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1705,7 +1702,6 @@ func TestGeneratorObjectAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/schemas_test.go
+++ b/internal/datasource/schemas_test.go
@@ -259,7 +259,6 @@ func TestGeneratorDataSourceSchemas_ModelsBytes(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/set_attribute_test.go
+++ b/internal/datasource/set_attribute_test.go
@@ -557,7 +557,6 @@ func TestGeneratorSetAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1153,7 +1152,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1245,7 +1243,6 @@ func TestGeneratorSetAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/set_nested_attribute_test.go
+++ b/internal/datasource/set_nested_attribute_test.go
@@ -562,7 +562,6 @@ func TestGeneratorSetNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1184,7 +1183,6 @@ func TestGeneratorSetNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1660,7 +1658,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1710,7 +1707,6 @@ func TestGeneratorSetNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/set_nested_block_test.go
+++ b/internal/datasource/set_nested_block_test.go
@@ -630,7 +630,6 @@ func TestGeneratorSetNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1302,7 +1301,6 @@ func TestGeneratorSetNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1776,7 +1774,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1826,7 +1823,6 @@ func TestGeneratorSetNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/single_nested_attribute_test.go
+++ b/internal/datasource/single_nested_attribute_test.go
@@ -367,7 +367,6 @@ func TestGeneratorSingleNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -737,7 +736,6 @@ func TestGeneratorSingleNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1068,7 +1066,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1119,7 +1116,6 @@ func TestGeneratorSingleNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/single_nested_block_test.go
+++ b/internal/datasource/single_nested_block_test.go
@@ -409,7 +409,6 @@ func TestGeneratorSingleNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -793,7 +792,6 @@ func TestGeneratorSingleNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1132,7 +1130,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1183,7 +1180,6 @@ func TestGeneratorSingleNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasource/string_attribute_test.go
+++ b/internal/datasource/string_attribute_test.go
@@ -150,7 +150,6 @@ func TestGeneratorStringAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -306,7 +305,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -392,7 +390,6 @@ func TestGeneratorStringAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/bool_attribute_test.go
+++ b/internal/provider/bool_attribute_test.go
@@ -141,7 +141,6 @@ func TestGeneratorBoolAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -394,7 +393,6 @@ func TestGeneratorBoolAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -538,7 +536,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -624,7 +621,6 @@ func TestGeneratorBoolAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/convert_test.go
+++ b/internal/provider/convert_test.go
@@ -426,7 +426,6 @@ func Test_NewSchemas(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/float64_attribute_test.go
+++ b/internal/provider/float64_attribute_test.go
@@ -130,7 +130,6 @@ func TestGeneratorFloat64Attribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -277,7 +276,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -363,7 +361,6 @@ func TestGeneratorFloat64Attribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/int64_attribute_test.go
+++ b/internal/provider/int64_attribute_test.go
@@ -130,7 +130,6 @@ func TestGeneratorInt64Attribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -278,7 +277,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -364,7 +362,6 @@ func TestGeneratorInt64Attribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/list_attribute_test.go
+++ b/internal/provider/list_attribute_test.go
@@ -508,7 +508,6 @@ func TestGeneratorListAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -951,7 +950,6 @@ func TestGeneratorListAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1530,7 +1528,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1622,7 +1619,6 @@ func TestGeneratorListAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/list_nested_attribute_test.go
+++ b/internal/provider/list_nested_attribute_test.go
@@ -526,7 +526,6 @@ func TestGeneratorListNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1148,7 +1147,6 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1600,7 +1598,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1650,7 +1647,6 @@ func TestGeneratorListNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/list_nested_block_test.go
+++ b/internal/provider/list_nested_block_test.go
@@ -630,7 +630,6 @@ func TestGeneratorListNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1302,7 +1301,6 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1777,7 +1775,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1827,7 +1824,6 @@ func TestGeneratorListNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/map_attribute_test.go
+++ b/internal/provider/map_attribute_test.go
@@ -507,7 +507,6 @@ func TestGeneratorMapAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1090,7 +1089,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1182,7 +1180,6 @@ func TestGeneratorMapAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/map_nested_attribute_test.go
+++ b/internal/provider/map_nested_attribute_test.go
@@ -526,7 +526,6 @@ func TestGeneratorMapNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1148,7 +1147,6 @@ func TestGeneratorMapNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1600,7 +1598,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1650,7 +1647,6 @@ func TestGeneratorMapNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/number_attribute_test.go
+++ b/internal/provider/number_attribute_test.go
@@ -130,7 +130,6 @@ func TestGeneratorNumberAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -278,7 +277,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -364,7 +362,6 @@ func TestGeneratorNumberAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/object_attribute_test.go
+++ b/internal/provider/object_attribute_test.go
@@ -382,7 +382,6 @@ func TestGeneratorObjectAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -828,7 +827,6 @@ func TestGeneratorObjectAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1580,7 +1578,6 @@ AttributeTypes: map[string]attr.Type{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1666,7 +1663,6 @@ func TestGeneratorObjectAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/schemas_test.go
+++ b/internal/provider/schemas_test.go
@@ -259,7 +259,6 @@ func TestGeneratorDataSourceSchemas_ModelsBytes(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/set_attribute_test.go
+++ b/internal/provider/set_attribute_test.go
@@ -507,7 +507,6 @@ func TestGeneratorSetAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1090,7 +1089,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1182,7 +1180,6 @@ func TestGeneratorSetAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/set_nested_attribute_test.go
+++ b/internal/provider/set_nested_attribute_test.go
@@ -526,7 +526,6 @@ func TestGeneratorSetNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1148,7 +1147,6 @@ func TestGeneratorSetNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1600,7 +1598,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1650,7 +1647,6 @@ func TestGeneratorSetNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/set_nested_block_test.go
+++ b/internal/provider/set_nested_block_test.go
@@ -630,7 +630,6 @@ func TestGeneratorSetNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1302,7 +1301,6 @@ func TestGeneratorSetNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1776,7 +1774,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1826,7 +1823,6 @@ func TestGeneratorSetNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/single_nested_attribute_test.go
+++ b/internal/provider/single_nested_attribute_test.go
@@ -347,7 +347,6 @@ func TestGeneratorSingleNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -717,7 +716,6 @@ func TestGeneratorSingleNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1031,7 +1029,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1082,7 +1079,6 @@ func TestGeneratorSingleNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/single_nested_block_test.go
+++ b/internal/provider/single_nested_block_test.go
@@ -409,7 +409,6 @@ func TestGeneratorSingleNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -793,7 +792,6 @@ func TestGeneratorSingleNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1132,7 +1130,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1183,7 +1180,6 @@ func TestGeneratorSingleNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/provider/string_attribute_test.go
+++ b/internal/provider/string_attribute_test.go
@@ -130,7 +130,6 @@ func TestGeneratorStringAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -277,7 +276,6 @@ my_other_validator.Validate(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -363,7 +361,6 @@ func TestGeneratorStringAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/bool_attribute_test.go
+++ b/internal/resource/bool_attribute_test.go
@@ -221,7 +221,6 @@ func TestGeneratorBoolAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -634,7 +633,6 @@ func TestGeneratorBoolAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -823,7 +821,6 @@ Default: my_bool_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -909,7 +906,6 @@ func TestGeneratorBoolAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/convert_test.go
+++ b/internal/resource/convert_test.go
@@ -448,7 +448,6 @@ func Test_NewSchemas(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/float64_attribute_test.go
+++ b/internal/resource/float64_attribute_test.go
@@ -221,7 +221,6 @@ func TestGeneratorFloat64Attribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -634,7 +633,6 @@ func TestGeneratorFloat64Attribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -823,7 +821,6 @@ Default: my_float64_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -909,7 +906,6 @@ func TestGeneratorFloat64Attribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/int64_attribute_test.go
+++ b/internal/resource/int64_attribute_test.go
@@ -221,7 +221,6 @@ func TestGeneratorInt64Attribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -634,7 +633,6 @@ func TestGeneratorInt64Attribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -823,7 +821,6 @@ Default: my_int64_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -909,7 +906,6 @@ func TestGeneratorInt64Attribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/list_attribute_test.go
+++ b/internal/resource/list_attribute_test.go
@@ -661,7 +661,6 @@ func TestGeneratorListAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1249,7 +1248,6 @@ func TestGeneratorListAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1858,7 +1856,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1950,7 +1947,6 @@ func TestGeneratorListAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/list_nested_attribute_test.go
+++ b/internal/resource/list_nested_attribute_test.go
@@ -683,7 +683,6 @@ func TestGeneratorListNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1357,7 +1356,6 @@ func TestGeneratorListNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1911,7 +1909,6 @@ Default: my_list_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1961,7 +1958,6 @@ func TestGeneratorListNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/list_nested_block_test.go
+++ b/internal/resource/list_nested_block_test.go
@@ -721,7 +721,6 @@ func TestGeneratorListNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1450,7 +1449,6 @@ func TestGeneratorListNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1986,7 +1984,6 @@ my_other_plan_modifier.Modify(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -2036,7 +2033,6 @@ func TestGeneratorListNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/map_attribute_test.go
+++ b/internal/resource/map_attribute_test.go
@@ -661,7 +661,6 @@ func TestGeneratorMapAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1249,7 +1248,6 @@ func TestGeneratorMapAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1858,7 +1856,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1950,7 +1947,6 @@ func TestGeneratorMapAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/map_nested_attribute_test.go
+++ b/internal/resource/map_nested_attribute_test.go
@@ -683,7 +683,6 @@ func TestGeneratorMapNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1357,7 +1356,6 @@ func TestGeneratorMapNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1911,7 +1909,6 @@ Default: my_map_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1961,7 +1958,6 @@ func TestGeneratorMapNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/number_attribute_test.go
+++ b/internal/resource/number_attribute_test.go
@@ -217,7 +217,6 @@ func TestGeneratorNumberAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -599,7 +598,6 @@ func TestGeneratorNumberAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -775,7 +773,6 @@ Default: my_number_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -861,7 +858,6 @@ func TestGeneratorNumberAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/object_attribute_test.go
+++ b/internal/resource/object_attribute_test.go
@@ -475,7 +475,6 @@ func TestGeneratorObjectAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1060,7 +1059,6 @@ func TestGeneratorObjectAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1879,7 +1877,6 @@ AttributeTypes: map[string]attr.Type{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1965,7 +1962,6 @@ func TestGeneratorObjectAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/schemas_test.go
+++ b/internal/resource/schemas_test.go
@@ -253,7 +253,6 @@ func TestGeneratorResourceSchemas_ModelsBytes(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/set_attribute_test.go
+++ b/internal/resource/set_attribute_test.go
@@ -661,7 +661,6 @@ func TestGeneratorSetAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1249,7 +1248,6 @@ func TestGeneratorSetAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1858,7 +1856,6 @@ ElementType: stringCustomType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1950,7 +1947,6 @@ func TestGeneratorSetAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/set_nested_attribute_test.go
+++ b/internal/resource/set_nested_attribute_test.go
@@ -683,7 +683,6 @@ func TestGeneratorSetNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1357,7 +1356,6 @@ func TestGeneratorSetNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1911,7 +1909,6 @@ Default: my_set_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1961,7 +1958,6 @@ func TestGeneratorSetNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/set_nested_block_test.go
+++ b/internal/resource/set_nested_block_test.go
@@ -721,7 +721,6 @@ func TestGeneratorSetNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1406,7 +1405,6 @@ func TestGeneratorSetNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1942,7 +1940,6 @@ my_other_plan_modifier.Modify(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1992,7 +1989,6 @@ func TestGeneratorSetNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/single_nested_attribute_test.go
+++ b/internal/resource/single_nested_attribute_test.go
@@ -436,7 +436,6 @@ func TestGeneratorSingleNestedAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -846,7 +845,6 @@ func TestGeneratorSingleNestedAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1221,7 +1219,6 @@ Default: my_object_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1272,7 +1269,6 @@ func TestGeneratorSingleNestedAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/single_nested_block_test.go
+++ b/internal/resource/single_nested_block_test.go
@@ -465,7 +465,6 @@ func TestGeneratorSingleNestedBlock_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -886,7 +885,6 @@ func TestGeneratorSingleNestedBlock_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1252,7 +1250,6 @@ my_other_plan_modifier.Modify(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1303,7 +1300,6 @@ func TestGeneratorSingleNestedBlock_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/resource/string_attribute_test.go
+++ b/internal/resource/string_attribute_test.go
@@ -221,7 +221,6 @@ func TestGeneratorStringAttribute_New(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -634,7 +633,6 @@ func TestGeneratorStringAttribute_Imports(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -823,7 +821,6 @@ Default: my_string_default.Default(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -909,7 +906,6 @@ func TestGeneratorStringAttribute_ModelField(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_bool_test.go
+++ b/internal/schema/custom_bool_test.go
@@ -32,7 +32,6 @@ return t.BoolType.Equal(other.BoolType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomBoolType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.BoolType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ BoolValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return boolValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -328,7 +321,6 @@ return v.BoolValue.Equal(other.BoolValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -367,7 +359,6 @@ return ExampleType{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -402,7 +393,6 @@ func TestCustomBoolValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -439,7 +429,6 @@ basetypes.BoolValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_float64_test.go
+++ b/internal/schema/custom_float64_test.go
@@ -32,7 +32,6 @@ return t.Float64Type.Equal(other.Float64Type)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomFloat64Type_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.Float64Type
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ Float64Value: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return boolValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -328,7 +321,6 @@ return v.Float64Value.Equal(other.Float64Value)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -367,7 +359,6 @@ return ExampleType{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -402,7 +393,6 @@ func TestCustomFloat64Value_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -439,7 +429,6 @@ basetypes.Float64Value
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_int64_test.go
+++ b/internal/schema/custom_int64_test.go
@@ -32,7 +32,6 @@ return t.Int64Type.Equal(other.Int64Type)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomInt64Type_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.Int64Type
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ Int64Value: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return boolValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -328,7 +321,6 @@ return v.Int64Value.Equal(other.Int64Value)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -367,7 +359,6 @@ return ExampleType{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -402,7 +393,6 @@ func TestCustomInt64Value_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -439,7 +429,6 @@ basetypes.Int64Value
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_list_test.go
+++ b/internal/schema/custom_list_test.go
@@ -32,7 +32,6 @@ return t.ListType.Equal(other.ListType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomListType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.ListType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ ListValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return listValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -326,7 +319,6 @@ return v.ListValue.Equal(other.ListValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -370,7 +362,6 @@ ElemType: types.BoolType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -407,7 +398,6 @@ func TestCustomListValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -446,7 +436,6 @@ basetypes.ListValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_map_test.go
+++ b/internal/schema/custom_map_test.go
@@ -32,7 +32,6 @@ return t.MapType.Equal(other.MapType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomMapType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.MapType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ MapValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return mapValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -326,7 +319,6 @@ return v.MapValue.Equal(other.MapValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -370,7 +362,6 @@ ElemType: types.BoolType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -407,7 +398,6 @@ func TestCustomMapValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -446,7 +436,6 @@ basetypes.MapValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_nested_object_test.go
+++ b/internal/schema/custom_nested_object_test.go
@@ -32,7 +32,6 @@ return t.ObjectType.Equal(other.ObjectType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomNestedObjectType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.ObjectType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -348,7 +344,6 @@ state: attr.ValueStateKnown,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -479,7 +474,6 @@ state: attr.ValueStateKnown,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -553,7 +547,6 @@ return NewExampleValueMust(ExampleValue{}.AttributeTypes(ctx), attributes), nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -608,7 +601,6 @@ return object
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -648,7 +640,6 @@ state: attr.ValueStateNull,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -686,7 +677,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -726,7 +716,6 @@ state: attr.ValueStateUnknown,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -770,7 +759,6 @@ return map[string]attr.Type{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -862,7 +850,6 @@ return true
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -900,7 +887,6 @@ return v.state == attr.ValueStateNull
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -938,7 +924,6 @@ return v.state == attr.ValueStateUnknown
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -976,7 +961,6 @@ return "ExampleValue"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1666,7 +1650,6 @@ return objVal, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1817,7 +1800,6 @@ panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1859,7 +1841,6 @@ AttrTypes: v.AttributeTypes(ctx),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1894,7 +1875,6 @@ func TestCustomNestedObjectValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1946,7 +1926,6 @@ state attr.ValueState
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_number_test.go
+++ b/internal/schema/custom_number_test.go
@@ -32,7 +32,6 @@ return t.NumberType.Equal(other.NumberType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomNumberType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.NumberType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ NumberValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return boolValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -328,7 +321,6 @@ return v.NumberValue.Equal(other.NumberValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -367,7 +359,6 @@ return ExampleType{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -402,7 +393,6 @@ func TestCustomNumberValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -439,7 +429,6 @@ basetypes.NumberValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_object_test.go
+++ b/internal/schema/custom_object_test.go
@@ -32,7 +32,6 @@ return t.ObjectType.Equal(other.ObjectType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomObjectType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.ObjectType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ ObjectValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return objectValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -326,7 +319,6 @@ return v.ObjectValue.Equal(other.ObjectValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -370,7 +362,6 @@ AttrTypes: v.AttributeTypes(ctx),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -407,7 +398,6 @@ func TestCustomObjectValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -446,7 +436,6 @@ basetypes.ObjectValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_set_test.go
+++ b/internal/schema/custom_set_test.go
@@ -32,7 +32,6 @@ return t.SetType.Equal(other.SetType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomSetType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.SetType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ SetValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return listValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -326,7 +319,6 @@ return v.SetValue.Equal(other.SetValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -370,7 +362,6 @@ ElemType: types.BoolType,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -407,7 +398,6 @@ func TestCustomSetValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -446,7 +436,6 @@ basetypes.SetValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/custom_string_test.go
+++ b/internal/schema/custom_string_test.go
@@ -32,7 +32,6 @@ return t.StringType.Equal(other.StringType)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -70,7 +69,6 @@ return "ExampleType"
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -105,7 +103,6 @@ func TestCustomStringType_renderTypable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -142,7 +139,6 @@ basetypes.StringType
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +182,6 @@ StringValue: in,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -242,7 +237,6 @@ return boolValuable, nil
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +274,6 @@ return ExampleValue{}
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -328,7 +321,6 @@ return v.StringValue.Equal(other.StringValue)
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -367,7 +359,6 @@ return ExampleType{
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -402,7 +393,6 @@ func TestCustomStringValue_renderValuable(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -439,7 +429,6 @@ basetypes.StringValue
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/framework_identifier_test.go
+++ b/internal/schema/framework_identifier_test.go
@@ -54,7 +54,7 @@ func TestFrameworkIdentifier_Valid(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -95,7 +95,7 @@ func TestFrameworkIdentifier_ToCamelCase(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -168,7 +168,7 @@ func TestFrameworkIdentifier_ToPrefixCamelCase(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -209,7 +209,7 @@ func TestFrameworkIdentifier_ToPascalCase(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -282,7 +282,7 @@ func TestFrameworkIdentifier_ToPrefixPascalCase(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/schema/to_from_bool_test.go
+++ b/internal/schema/to_from_bool_test.go
@@ -49,7 +49,6 @@ types.BoolPointerValue(*apiObject),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -112,7 +111,6 @@ return &a, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_float64_test.go
+++ b/internal/schema/to_from_float64_test.go
@@ -49,7 +49,6 @@ types.Float64PointerValue(*apiObject),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -112,7 +111,6 @@ return &a, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_int64_test.go
+++ b/internal/schema/to_from_int64_test.go
@@ -49,7 +49,6 @@ types.Int64PointerValue(*apiObject),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -112,7 +111,6 @@ return &a, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_list_test.go
+++ b/internal/schema/to_from_list_test.go
@@ -71,7 +71,6 @@ l,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -148,7 +147,6 @@ return &apisdkType, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_map_test.go
+++ b/internal/schema/to_from_map_test.go
@@ -71,7 +71,6 @@ l,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -148,7 +147,6 @@ return &apisdkType, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_nested_object_test.go
+++ b/internal/schema/to_from_nested_object_test.go
@@ -370,7 +370,6 @@ state: attr.ValueStateKnown,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -929,7 +928,6 @@ String: typeFieldString.ValueStringPointer(),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_number_test.go
+++ b/internal/schema/to_from_number_test.go
@@ -49,7 +49,6 @@ types.NumberValue(*apiObject),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -112,7 +111,6 @@ return &a, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_object_test.go
+++ b/internal/schema/to_from_object_test.go
@@ -73,7 +73,6 @@ o,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -218,7 +217,6 @@ return &apisdkType, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_set_test.go
+++ b/internal/schema/to_from_set_test.go
@@ -71,7 +71,6 @@ l,
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -148,7 +147,6 @@ return &apisdkType, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/schema/to_from_string_test.go
+++ b/internal/schema/to_from_string_test.go
@@ -49,7 +49,6 @@ types.StringPointerValue(*apiObject),
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -112,7 +111,6 @@ return &a, diags
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
- Replace `max-per-linter` with `max-issues-per-linters`
- Replace `exportloopref` linter with `copyloopvar`
- Replace `tenv` linter with `usetesting`